### PR TITLE
Add missing peer dependency for Leaflet

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,20 +17,21 @@
     "express": "^4.13.3",
     "history": "^1.13.0",
     "isomorphic-fetch": "^2.2.0",
+    "leaflet": "^0.7.7",
     "lodash": "^3.10.1",
     "react": "^0.14.1",
     "react-bootstrap": "^0.27.3",
     "react-dom": "^0.14.1",
     "react-helmet": "^2.1.1",
     "react-intl": "^2.0.0-beta-1",
+    "react-leaflet": "^0.8.1",
     "react-redux": "^4.0.0",
     "react-router": "^1.0.0-rc3",
     "redux": "^3.0.4",
     "redux-actions": "^0.8.0",
     "redux-router": "^1.0.0-beta3",
     "redux-thunk": "^1.0.0",
-    "updeep": "^0.10.1",
-    "react-leaflet": "^0.8.1"
+    "updeep": "^0.10.1"
   },
   "devDependencies": {
     "autoprefixer": "^6.0.3",


### PR DESCRIPTION
This is really only an issue on npm 3+