### PR TITLE
Add build script for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node server --server-rendering",
+    "build": "bower i",
     "dev": "node server --dev",
     "lint": "eslint src server test",
     "test": "env NODE_PATH=./src mocha --compilers js:babel-register --recursive --require ./test/setup.js",


### PR DESCRIPTION
Idea here is to have a single preparation command "npm run build". This command is supposed to performs all steps beyond "npm i", that are necessary to prepare the codebase for running within a process manager.
npm also supports lifecycle events for automating this, but I cannot tell if using them would cause difficulties elsewhere.