### PR TITLE
Set max bounds to hearing map

### DIFF
--- a/src/components/OverviewMap.js
+++ b/src/components/OverviewMap.js
@@ -47,7 +47,14 @@ class OverviewMap extends React.Component {
           ref={(input) => {
             if (!input) return;
             const bounds = input.getLeafletElement().getBounds();
-            if (bounds.isValid()) input.props.map.fitBounds(bounds);
+            if (bounds.isValid()) {
+              input.props.map.fitBounds(bounds);
+              const viewportBounds = [
+                [60.1, 24.75],  // SouthWest corner
+                [60.35, 25.3]  // NorthEast corner
+              ];  // Wide Bounds of City of Helsinki area
+              input.props.map.setMaxBounds(viewportBounds);
+            }
           }}
         >{contents}</FeatureGroup>
       </Map>);

--- a/src/components/OverviewMap.js
+++ b/src/components/OverviewMap.js
@@ -38,7 +38,7 @@ class OverviewMap extends React.Component {
     }
     const position = [60.192059, 24.945831];  // Default to Helsinki's center
     return (
-      <Map center={position} zoom={13} style={style}>
+      <Map center={position} zoom={13} style={style} minZoom={10}>
         <TileLayer
           url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
           attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'


### PR DESCRIPTION
Properly set max bounds makes sure that the hearing map can't be
accidentally scrolled or zoomed out of the Helsinki area.

This should improve the user experience of the map component.

Refs: #204