### PR TITLE
Thumb vote (resubmission)

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -15,6 +15,9 @@ function checkResponseStatus(response) {
 
 function getResponseJSON(response) {
   checkResponseStatus(response);
+  if (response.status === 304) {
+    return {status_code: response.status};
+  }
   return response.json();
 }
 
@@ -99,7 +102,11 @@ export function postVote(commentId, hearingId, sectionId) {
       dispatch(createAction("postedCommentVote")({commentId, hearingId, sectionId, data}));
       dispatch(fetchHearing(hearingId));
       dispatch(fetchSectionComments(hearingId, sectionId));
-      notifySuccess("Ääni vastaanotettu. Kiitos!");
+      if (data.status_code === 304) {
+        notifyError("Olet jo antanut äänesi tälle kommentille.");
+      } else {
+        notifySuccess("Ääni vastaanotettu. Kiitos!");
+      }
     }).catch(requestErrorHandler(dispatch, fetchAction));
   };
 }

--- a/src/components/Comment.js
+++ b/src/components/Comment.js
@@ -2,20 +2,21 @@ import React from 'react';
 import {injectIntl, FormattedMessage, FormattedRelative} from 'react-intl';
 import Button from 'react-bootstrap/lib/Button';
 import Icon from 'utils/Icon';
+import {notifyError} from '../utils/notify';
+
 
 class Comment extends React.Component {
   onVote() {
-    const {data} = this.props;
-    this.props.onPostVote(data.id, data.section);
+    if (this.props.canVote) {
+      const {data} = this.props;
+      this.props.onPostVote(data.id, data.section);
+    } else {
+      notifyError("Kirjaudu sisään äänestääksesi kommenttia.");
+    }
   }
 
   render() {
-    const {data, canVote} = this.props;
-    const voteButton = (canVote ?
-        <Button className="btn-sm hearing-comment-vote-link" onClick={this.onVote.bind(this)}>
-          <Icon name="thumbs-o-up"/> <FormattedMessage id="vote"/>
-        </Button> : null
-    );
+    const {data} = this.props;
     const authorName = data.author_name || (data.created_by ? data.created_by.username : null);
     if (!data.content) {
       return null;
@@ -24,7 +25,9 @@ class Comment extends React.Component {
     return (<div className="hearing-comment">
       <div className="hearing-comment-header clearfix">
         <div className="hearing-comment-votes">
-          <Icon name="thumbs-o-up"/> {data.n_votes}
+          <Button className="btn-sm hearing-comment-vote-link" onClick={this.onVote.bind(this)}>
+            <Icon name="thumbs-o-up"/> {data.n_votes}
+          </Button>
         </div>
         <div className="hearing-comment-publisher">
           <span className="hearing-comment-user">{authorName || <FormattedMessage id="anonymous"/>}</span>
@@ -33,7 +36,6 @@ class Comment extends React.Component {
       </div>
       <div className="hearing-comment-body">
         <p>{data.content}</p>
-        {voteButton}
       </div>
     </div>);
   }

--- a/test/comment.js
+++ b/test/comment.js
@@ -16,4 +16,18 @@ domDescribe('Comment', () => {
     const comp = renderIntoDocument(wireComponent({}, Comment, {data: anonComment}));
     expect(findDOMNode(comp).className).to.contain("hearing-comment");
   });
+
+  it('should have a clickable voting thumb', () => {
+    const anonComment = {
+      "id": "f00f00",
+      "hearing": "f00f00",
+      "content": "Reiciendis",
+      "n_votes": 2,
+      "created_by": null,
+      "created_at": "2015-11-16T09:25:37.625607Z"
+    };
+    const comp = renderIntoDocument(wireComponent({}, Comment, {data: anonComment}));
+    const voteBtn = findDOMNode(comp).getElementsByClassName("hearing-comment-votes")[0];
+    expect(voteBtn.innerHTML).to.contain("button");
+  });
 });


### PR DESCRIPTION
**Supersedes:** #212
**Fixes:** #203
<hr>

Removed previously used vote button from comment and changed the thumb to act as a
vote button.

Thumb is always clickable, but when user can not vote, an error
message is shown.

Refs: #203

**Screenshot of the voting thumb**
![vote](https://cloud.githubusercontent.com/assets/3500484/15711540/16ca2456-2817-11e6-98dc-5fb5cad81645.PNG)

**Login to vote**
![login_to_vote](https://cloud.githubusercontent.com/assets/3500484/15711626/7e94c320-2817-11e6-85cf-747956530655.png)
