### PR TITLE
Downgrade react-leaflet version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-dom": "^15.1.0",
     "react-helmet": "^2.2.0",
     "react-intl": "2.0.0-rc-1",
-    "react-leaflet": "^0.12.0",
+    "react-leaflet": "^0.11.5",
     "react-nl2br": "^0.1.1",
     "react-overlays": "^0.6.0",
     "react-redux": "^4.0.0",


### PR DESCRIPTION
react-leaflet-draw (which will be need in admin UI) doesn't work with
react-leaflet@0.12.

Information about the breaking change:
https://github.com/PaulLeCam/react-leaflet/blob/master/CHANGELOG.md#v0120-2016-06-25