### PR TITLE
Upgrade bs and leaflet

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "progress": "^1.1.8",
     "query-string": "^4.2.2",
     "react": "^15.1.0",
-    "react-bootstrap": "^0.29.5",
+    "react-bootstrap": "^0.30.5",
     "react-dom": "^15.1.0",
     "react-helmet": "^2.2.0",
     "react-intl": "2.0.0-rc-1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-dom": "^15.1.0",
     "react-helmet": "^2.2.0",
     "react-intl": "2.0.0-rc-1",
-    "react-leaflet": "^0.11.5",
+    "react-leaflet": "^0.11.7",
     "react-nl2br": "^0.1.1",
     "react-overlays": "^0.6.0",
     "react-redux": "^4.0.0",

--- a/src/components/BaseCommentForm.js
+++ b/src/components/BaseCommentForm.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import {intlShape, FormattedMessage} from 'react-intl';
 import Button from 'react-bootstrap/lib/Button';
-import Input from 'react-bootstrap/lib/Input';
+import FormControl from 'react-bootstrap/lib/FormControl';
+import FormGroup from 'react-bootstrap/lib/FormGroup';
 import Icon from 'utils/Icon';
 import CommentDisclaimer from './CommentDisclaimer';
 
@@ -81,16 +82,22 @@ class BaseCommentForm extends React.Component {
       return (<div className="comment-form">
         <form>
           <h3><FormattedMessage id="writeComment"/></h3>
-          <Input type="textarea" value={this.state.commentText} onChange={this.handleTextChange.bind(this)}/>
+          <FormControl
+            componentClass="textarea"
+            value={this.state.commentText}
+            onChange={this.handleTextChange.bind(this)}
+          />
           {canSetNickname ? <h3><FormattedMessage id="nickname"/></h3> : null}
           {canSetNickname ? (
-            <Input
-              type="text"
-              placeholder={this.props.intl.formatMessage({id: "anonymous"})}
-              value={this.state.nickname}
-              onChange={this.handleNicknameChange.bind(this)}
-              maxLength={32}
-            />
+            <FormGroup>
+              <FormControl
+                type="text"
+                placeholder={this.props.intl.formatMessage({id: "anonymous"})}
+                value={this.state.nickname}
+                onChange={this.handleNicknameChange.bind(this)}
+                maxLength={32}
+              />
+            </FormGroup>
           ) : null}
           <div className="comment-buttons clearfix">
             <Button bsStyle="warning" onClick={this.toggle.bind(this)}>

--- a/src/components/plugins/mapdon-hkr.js
+++ b/src/components/plugins/mapdon-hkr.js
@@ -1,7 +1,8 @@
 import Button from 'react-bootstrap/lib/Button';
 import BaseCommentForm from '../BaseCommentForm';
 import CommentDisclaimer from "../CommentDisclaimer";
-import Input from 'react-bootstrap/lib/Input';
+import FormControl from 'react-bootstrap/lib/FormControl';
+import FormGroup from 'react-bootstrap/lib/FormGroup';
 import React from 'react';
 import {injectIntl} from 'react-intl';
 import {alert} from '../../utils/notify';
@@ -27,11 +28,13 @@ export class MapdonHKRPlugin extends BaseCommentForm {
             ref="frame"
           ></iframe>
           <br/>
-          <Input
-            type="textarea"
-            onChange={this.handleTextChange.bind(this)}
-            placeholder="Kommentoi ehdotustasi tässä."
-          />
+          <FormGroup>
+            <FormControl
+              componentClass="textarea"
+              onChange={this.handleTextChange.bind(this)}
+              placeholder="Kommentoi ehdotustasi tässä."
+            />
+          </FormGroup>
           <p>
             <Button bsStyle="primary" onClick={this.getDataAndSubmitComment.bind(this)} disabled={buttonDisabled}>
               Lähetä ehdotus

--- a/src/components/plugins/mapdon-ksv.js
+++ b/src/components/plugins/mapdon-ksv.js
@@ -1,7 +1,8 @@
 import Button from 'react-bootstrap/lib/Button';
 import BaseCommentForm from '../BaseCommentForm';
 import CommentDisclaimer from "../CommentDisclaimer";
-import Input from 'react-bootstrap/lib/Input';
+import FormControl from 'react-bootstrap/lib/FormControl';
+import FormGroup from 'react-bootstrap/lib/FormGroup';
 import React from 'react';
 import {injectIntl, FormattedMessage} from 'react-intl';
 import {alert} from '../../utils/notify';
@@ -23,21 +24,25 @@ class MapdonKSVPlugin extends BaseCommentForm {
     const commentBox = (
       <div>
         <br/>
-        <Input
-          type="textarea"
-          onChange={this.handleTextChange.bind(this)}
-          value={this.state.commentText}
-          placeholder="Kommentoi ehdotustasi tässä."
-        />
+        <FormGroup>
+          <FormControl
+            componentClass="textarea"
+            onChange={this.handleTextChange.bind(this)}
+            value={this.state.commentText}
+            placeholder="Kommentoi ehdotustasi tässä."
+          />
+        </FormGroup>
         {canSetNickname ? <h3><FormattedMessage id="nickname"/></h3> : null}
         {canSetNickname ? (
-          <Input
-            type="text"
-            placeholder={this.props.intl.formatMessage({id: "anonymous"})}
-            value={this.state.nickname}
-            onChange={this.handleNicknameChange.bind(this)}
-            maxLength={32}
-          />
+          <FormGroup>
+            <FormControl
+              type="text"
+              placeholder={this.props.intl.formatMessage({id: "anonymous"})}
+              value={this.state.nickname}
+              onChange={this.handleNicknameChange.bind(this)}
+              maxLength={32}
+            />
+          </FormGroup>
         ) : null}
         <p>
           <Button bsStyle="primary" onClick={this.getDataAndSubmitComment.bind(this)} disabled={buttonDisabled}>


### PR DESCRIPTION
Upgrade react-bootstrap from 0.29.5 to 0.30.5
- [Changelog](https://github.com/react-bootstrap/react-bootstrap/blob/master/CHANGELOG.md#v0300)
- Required replacing `Input` components with `FormControl`s

Upgrade react-leaflet from 0.11.5 to 0.11.7
- [Changelog](https://github.com/PaulLeCam/react-leaflet/blob/master/CHANGELOG.md#v0117-2016-06-14)
- Bug fixes. Seemed to work, though automated test coverage is mostly non-existing.