### PR TITLE
Upgrade react-leaflet from 0.11.7 to ^0.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-dom": "^15.1.0",
     "react-helmet": "^2.2.0",
     "react-intl": "2.0.0-rc-1",
-    "react-leaflet": "^0.11.7",
+    "react-leaflet": "^0.12.3",
     "react-nl2br": "^0.1.1",
     "react-overlays": "^0.6.0",
     "react-redux": "^4.0.0",

--- a/src/components/OverviewMap.js
+++ b/src/components/OverviewMap.js
@@ -46,7 +46,7 @@ class OverviewMap extends React.Component {
         <FeatureGroup
           ref={(input) => {
             if (!input) return;
-            const bounds = input.getLeafletElement().getBounds();
+            const bounds = input.leafletElement.getBounds();
             if (bounds.isValid()) {
               input.props.map.fitBounds(bounds);
               const viewportBounds = [


### PR DESCRIPTION
This gives us some bug fixes, but most notably support for newer
versions of react-leaflet-draw which is required by becoming admin UI.

[Changelog](https://github.com/PaulLeCam/react-leaflet/blob/master/CHANGELOG.md)

From the changelog.

> [BREAKING] Moved Leaflet instances injection from props to context. All components provided by this lib should continue to work as expected, but custom components need to be updated. Read the UPGRADING file for more information.

That change breaks newer versions of `react-leaflet-draw` and that's the main reason for this upgrade.