### PR TITLE
Fix fullscreen map height problem on IE's

### DIFF
--- a/assets/less/hel/fullscreen-map-plugin.less
+++ b/assets/less/hel/fullscreen-map-plugin.less
@@ -90,8 +90,13 @@
         right: 0;
         overflow: hidden;
 
+        .plugin-comment-form {
+            height: 100%;
+        }
+
         form {
             margin: 0;
+            height: 100%;
         }
 
         iframe {


### PR DESCRIPTION
Few elements lacked height 100% to support fullscreen map plugin
properly on IE browsers.