### PR TITLE
Prepare for upcoming API change regarding hearing.labels

### DIFF
--- a/__tests__/LabelList.react-test.js
+++ b/__tests__/LabelList.react-test.js
@@ -1,0 +1,37 @@
+// LabelList.react-test.js
+import React from 'react';
+import LabelList from '../src/components/LabelList';
+import renderer from 'react-test-renderer';
+
+
+test('LabelList can handle list of label strings', () => {
+  const labels = ["fancy", "test"];
+  const component = renderer.create(
+    <LabelList className="labels" labels={labels} />
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+
+test('LabelList can handle empty list', () => {
+  const component = renderer.create(
+    <LabelList className="labels" labels={[]} />
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+
+test('LabelList can handle list of label objects', () => {
+  const labels = [
+    {id: 1, label: "such"},
+    {id: 2, label: "label"},
+  ];
+  const component = renderer.create(
+    <LabelList className="labels" labels={labels} />
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+

--- a/__tests__/__snapshots__/LabelList.react-test.js.snap
+++ b/__tests__/__snapshots__/LabelList.react-test.js.snap
@@ -1,0 +1,44 @@
+exports[`test LabelList can handle empty list 1`] = `
+<div
+  className="labels" />
+`;
+
+exports[`test LabelList can handle list of label objects 1`] = `
+<div
+  className="labels">
+  <span>
+    <span
+      className="label label-default">
+      such
+    </span>
+     
+  </span>
+  <span>
+    <span
+      className="label label-default">
+      label
+    </span>
+     
+  </span>
+</div>
+`;
+
+exports[`test LabelList can handle list of label strings 1`] = `
+<div
+  className="labels">
+  <span>
+    <span
+      className="label label-default">
+      fancy
+    </span>
+     
+  </span>
+  <span>
+    <span
+      className="label label-default">
+      test
+    </span>
+     
+  </span>
+</div>
+`;

--- a/src/components/LabelList.js
+++ b/src/components/LabelList.js
@@ -1,10 +1,23 @@
+import _ from 'lodash';
 import React from 'react';
 import Label from 'react-bootstrap/lib/Label';
 
 class LabelList extends React.Component {
   render() {
     const {labels, className} = this.props;
-    return (<div className={className}>{labels.map((label) => <span key={label}><Label>{label}</Label> </span>)}</div>);
+    /*
+    * Hearing.labels
+    *     Old API response: [String]
+    *     New API response: [{id, label}]
+    * TODO: Remove support for old styled API response when API has changed.
+     */
+    const newerLabelToHTML = ((label) => <span key={label.id}><Label>{label.label}</Label> </span>);
+    const oldLabelToHTML = ((label) => <span key={label}><Label>{label}</Label> </span>);
+    return (
+      <div className={className}>
+        {labels.map(_.isString(labels[0]) ? oldLabelToHTML : newerLabelToHTML)}
+      </div>
+    );
   }
 }
 


### PR DESCRIPTION
Hearing.labels are used to be sent as list of strings, but because UI
needs labels ids the API is going to change. Therefore LabelList now
supports the old response format, but also the future response format
which means labels will be list of objects containing both id and label.

![1eqhgz 1](https://cloud.githubusercontent.com/assets/3500484/20589291/32f74932-b224-11e6-839a-2d3e886ff0a9.jpg)
