### PR TITLE
Open hearings as card grid on front page

### DIFF
--- a/assets/less/app.less
+++ b/assets/less/app.less
@@ -66,3 +66,5 @@
 @import "hel/footer";
 @import "hel/fullscreen-map-plugin";
 @import "hel/fullwidth-hearing";
+@import "hel/hearing-card";
+@import "hel/hearing-card-list";

--- a/assets/less/hel/common.less
+++ b/assets/less/hel/common.less
@@ -123,4 +123,5 @@ a.fullwidth {
   padding: @navbar-padding-vertical;
   background: @brand-gray-light;
   text-align: center;
+  margin-bottom: 15px;
 }

--- a/assets/less/hel/common.less
+++ b/assets/less/hel/common.less
@@ -116,3 +116,11 @@ a.list-group-item {
         color: white;
     }
 }
+
+a.fullwidth {
+  display: block;
+  width: 100%;
+  padding: @navbar-padding-vertical;
+  background: @brand-gray-light;
+  text-align: center;
+}

--- a/assets/less/hel/fullwidth-hearing.less
+++ b/assets/less/hel/fullwidth-hearing.less
@@ -1,7 +1,7 @@
 .fullwidth-hearing {
+  background: @missing-image;
   background-size: cover;
   background-position: center center;
-  background: @missing-image;
   min-height: 250px;
   padding: 30px;
   width: 100%;

--- a/assets/less/hel/fullwidth-hearing.less
+++ b/assets/less/hel/fullwidth-hearing.less
@@ -1,6 +1,7 @@
 .fullwidth-hearing {
   background-size: cover;
   background-position: center center;
+  background: @missing-image;
   min-height: 250px;
   padding: 30px;
   width: 100%;

--- a/assets/less/hel/hearing-card-list.less
+++ b/assets/less/hel/hearing-card-list.less
@@ -1,20 +1,26 @@
 .hearing-card-list {
-  display: flex;
-  flex-wrap: wrap;
-
-  &:before {
-    // Fix flex-wrap bug with Bootstrap Row in Safari
-    content: none !important;
-  }
 
   & > [class*='col-'] {
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    padding: 10px;
+    padding: 15px;
+  }
 
-    & > * {
-      flex-grow: 1;
+  @media (min-width: @screen-sm-min) {
+    display: flex;
+    flex-wrap: wrap;
+
+    &:before {
+      // Fix flex-wrap bug with Bootstrap Row in Safari
+      content: none !important;
+    }
+
+    & > [class*='col-'] {
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+
+      & > * {
+        flex-grow: 1;
+      }
     }
   }
 }

--- a/assets/less/hel/hearing-card-list.less
+++ b/assets/less/hel/hearing-card-list.less
@@ -1,0 +1,20 @@
+.hearing-card-list {
+  display: flex;
+  flex-wrap: wrap;
+
+  &:before {
+    // Fix flex-wrap bug with Bootstrap Row in Safari
+    content: none !important;
+  }
+
+  & > [class*='col-'] {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    padding: 10px;
+
+    & > * {
+      flex-grow: 1;
+    }
+  }
+}

--- a/assets/less/hel/hearing-card.less
+++ b/assets/less/hel/hearing-card.less
@@ -4,7 +4,7 @@
 
   &-image {
     height: 170px;
-    background-color: @brand-gray-light;
+    background: @missing-image;
     background-size: cover;
     background-position: center center;
     position: relative;
@@ -15,22 +15,7 @@
       right: 0;
       padding: 3px 10px;
       font-size: 1.5em;
-      text-shadow:  1px 1px 1px @brand-gray-light,
-                    -1px -1px 1px @brand-gray-light,
-                    1px -1px 1px @brand-gray-light,
-                    -1px 1px 1px @brand-gray-light,
-                    1px 0px 1px @brand-gray-light,
-                    -1px 0px 1px @brand-gray-light,
-                    0px 1px 1px @brand-gray-light,
-                    0px -1px 1px @brand-gray-light,
-                    3px 3px 5px @brand-gray-light,
-                    -3px -3px 5px @brand-gray-light,
-                    3px -3px 5px @brand-gray-light,
-                    -3px 3px 5px @brand-gray-light,
-                    3px 0px 5px @brand-gray-light,
-                    -3px 0px 5px @brand-gray-light,
-                    0px 3px 5px @brand-gray-light,
-                    0px -3px 5px @brand-gray-light;
+      text-shadow: @comment-count-shadow;
     }
   }
 

--- a/assets/less/hel/hearing-card.less
+++ b/assets/less/hel/hearing-card.less
@@ -25,6 +25,10 @@
     .hearing-card-time {
       color: @text-muted;
       font-size: 1.4rem;
+
+      &.expires {
+        color: red;
+      }
     }
   }
 

--- a/assets/less/hel/hearing-card.less
+++ b/assets/less/hel/hearing-card.less
@@ -1,0 +1,61 @@
+.hearing-card {
+  border: 1px solid @border-color;
+  word-wrap: break-word;
+  position: relative;
+
+  &-image {
+    height: 170px;
+    background-color: @brand-gray-light;
+    background-size: cover;
+    position: relative;
+
+    .hearing-card-comment-count {
+      position: absolute;
+      bottom: 0;
+      right: 0;
+      padding: 3px;
+      text-shadow:  1px 1px 1px @brand-gray-light,
+                    -1px -1px 1px @brand-gray-light,
+                    1px -1px 1px @brand-gray-light,
+                    -1px 1px 1px @brand-gray-light,
+                    1px 0px 1px @brand-gray-light,
+                    -1px 0px 1px @brand-gray-light,
+                    0px 1px 1px @brand-gray-light,
+                    0px -1px 1px @brand-gray-light,
+                    3px 3px 5px @brand-gray-light,
+                    -3px -3px 5px @brand-gray-light,
+                    3px -3px 5px @brand-gray-light,
+                    -3px 3px 5px @brand-gray-light,
+                    3px 0px 5px @brand-gray-light,
+                    -3px 0px 5px @brand-gray-light,
+                    0px 3px 5px @brand-gray-light,
+                    0px -3px 5px @brand-gray-light;
+    }
+  }
+
+  &-content {
+    padding: @padding-base-vertical @padding-base-horizontal;
+
+    .hearing-card-time {
+      color: @text-muted;
+      font-size: 1.4rem;
+    }
+  }
+
+  &-notice {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 1000;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.6);
+    max-width: 100%;
+
+    .hearing-card-notice-content {
+      background: @gray-light;
+      color: #fff;
+      opacity: 1;
+      padding: 5px;
+    }
+  }
+}

--- a/assets/less/hel/hearing-card.less
+++ b/assets/less/hel/hearing-card.less
@@ -1,19 +1,20 @@
 .hearing-card {
   border: 1px solid @border-color;
-  word-wrap: break-word;
   position: relative;
 
   &-image {
     height: 170px;
     background-color: @brand-gray-light;
     background-size: cover;
+    background-position: center center;
     position: relative;
 
     .hearing-card-comment-count {
       position: absolute;
       bottom: 0;
       right: 0;
-      padding: 3px;
+      padding: 3px 10px;
+      font-size: 1.5em;
       text-shadow:  1px 1px 1px @brand-gray-light,
                     -1px -1px 1px @brand-gray-light,
                     1px -1px 1px @brand-gray-light,

--- a/assets/less/hel/hearing-card.less
+++ b/assets/less/hel/hearing-card.less
@@ -9,6 +9,7 @@
     background-size: cover;
     background-position: center center;
     position: relative;
+    color: @text-color;
 
     .hearing-card-comment-count {
       position: absolute;

--- a/assets/less/hel/hearing-card.less
+++ b/assets/less/hel/hearing-card.less
@@ -3,6 +3,7 @@
   position: relative;
 
   &-image {
+    display: block;
     height: 170px;
     background: @missing-image;
     background-size: cover;

--- a/assets/less/hel/variables.less
+++ b/assets/less/hel/variables.less
@@ -884,9 +884,12 @@
 //** Horizontal line color.
 @hr-border:                   @border-color;
 
-//== Comment count
+//== Hearing Cards
 //
 //##
+
+//** Missing image background
+@missing-image:               linear-gradient(-45deg, @hel-light-blue, @hel-blue);
 
 //** Comment count text shadow when overlayed over image
 @comment-count-shadow:        1px 1px 1px @brand-gray-light,

--- a/assets/less/hel/variables.less
+++ b/assets/less/hel/variables.less
@@ -889,7 +889,7 @@
 //##
 
 //** Missing image background
-@missing-image:               linear-gradient(-45deg, @hel-light-blue, @hel-blue);
+@missing-image:               linear-gradient(-45deg, @hel-blue, @hel-light-blue, @hel-blue);
 
 //** Comment count text shadow when overlayed over image
 @comment-count-shadow:        1px 1px 1px @brand-gray-light,

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "lodash": "^4.17.2",
     "markdown-loader": "^0.1.7",
     "minimist": "^1.2.0",
+    "moment": "^2.17.1",
     "morgan": "^1.6.1",
     "nconf": "^0.8.2",
     "node-fetch": "^1.3.3",

--- a/src/components/FullWidthHearing.js
+++ b/src/components/FullWidthHearing.js
@@ -7,7 +7,9 @@ import getAttr from '../utils/getAttr';
 
 const FullWidthHearing = ({hearing, className = '', ...rest}, {language}) => {
   const styles = {
-    backgroundImage: `url(${hearing && hearing.main_image.url})`
+    backgroundImage: hearing && hearing.main_image && hearing.main_image.url ?
+    `url(${hearing && hearing.main_image && hearing.main_image.url})` :
+    ''
   };
   return (
     <div className={`fullwidth-hearing ${className}`} style={styles} {...rest}>

--- a/src/components/FullWidthHearing.js
+++ b/src/components/FullWidthHearing.js
@@ -2,14 +2,13 @@ import React from 'react';
 import {Link} from 'react-router';
 import Icon from '../utils/Icon';
 import formatRelativeTime from '../utils/formatRelativeTime';
-import {getHearingURL} from '../utils/hearing';
+import {getHearingURL, getHearingMainImageURL} from '../utils/hearing';
 import getAttr from '../utils/getAttr';
 
 const FullWidthHearing = ({hearing, className = '', ...rest}, {language}) => {
+  const backgroundImage = getHearingMainImageURL(hearing);
   const styles = {
-    backgroundImage: hearing && hearing.main_image && hearing.main_image.url ?
-    `url(${hearing && hearing.main_image && hearing.main_image.url})` :
-    ''
+    backgroundImage: backgroundImage ? `url(${backgroundImage})` : ''
   };
   return (
     <div className={`fullwidth-hearing ${className}`} style={styles} {...rest}>

--- a/src/components/HearingCard.js
+++ b/src/components/HearingCard.js
@@ -25,11 +25,11 @@ const HearingCard = ({hearing, language}) => {
           </div>
         </div>
       }
-      <div className="hearing-card-image" style={imageStyle}>
+      <Link to={getHearingURL(hearing)} className="hearing-card-image" style={imageStyle}>
         <div className="hearing-card-comment-count">
           <Icon name="comment-o"/>&nbsp;{hearing.n_comments}
         </div>
-      </div>
+      </Link>
       <div className="hearing-card-content">
         <div className={`hearing-card-time ${expiresSoon ? 'expires' : ''}`}>
           {formatRelativeTime("timeClose", hearing.close_at)}

--- a/src/components/HearingCard.js
+++ b/src/components/HearingCard.js
@@ -6,6 +6,7 @@ import Icon from '../utils/Icon';
 import LabelList from './LabelList';
 import getAttr from '../utils/getAttr';
 import {getHearingURL} from '../utils/hearing';
+import moment from 'moment';
 
 const HearingCard = ({hearing, language}) => {
   const imageStyle = {
@@ -13,7 +14,7 @@ const HearingCard = ({hearing, language}) => {
   };
   // FIXME: Should there be direct linking to hearing using certain language?
   const translationAvailable = !!getAttr(hearing.title, language/* , {exact: true} */);
-
+  const expiresSoon = moment(hearing.close_at).diff(moment(), 'weeks') < 1;
   return (
     <div className="hearing-card">
       {
@@ -30,7 +31,7 @@ const HearingCard = ({hearing, language}) => {
         </div>
       </div>
       <div className="hearing-card-content">
-        <div className="hearing-card-time">
+        <div className={`hearing-card-time ${expiresSoon ? 'expires' : ''}`}>
           {formatRelativeTime("timeClose", hearing.close_at)}
         </div>
         <h4 className="hearing-card-title">

--- a/src/components/HearingCard.js
+++ b/src/components/HearingCard.js
@@ -1,0 +1,54 @@
+import React, {PropTypes} from 'react';
+import {FormattedMessage} from 'react-intl';
+import {Link} from 'react-router';
+import formatRelativeTime from '../utils/formatRelativeTime';
+import Icon from '../utils/Icon';
+import LabelList from './LabelList';
+import getAttr from '../utils/getAttr';
+import {getHearingURL} from '../utils/hearing';
+
+const HearingCard = ({hearing, language}) => {
+  const imageStyle = {
+    backgroundImage: hearing.main_image ? `url(${hearing.main_image.url})` : ''
+  };
+  // FIXME: Should there be direct linking to hearing using certain language?
+  const translationAvailable = !!getAttr(hearing.title, language/* , {exact: true} */);
+
+  return (
+    <div className="hearing-card">
+      {
+        !translationAvailable &&
+        <div className="hearing-card-notice">
+          <div className="hearing-card-notice-content">
+            <FormattedMessage id="hearingTranslationNotAvailable"/>
+          </div>
+        </div>
+      }
+      <div className="hearing-card-image" style={imageStyle}>
+        <div className="hearing-card-comment-count">
+          <Icon name="comment-o"/>&nbsp;{hearing.n_comments}
+        </div>
+      </div>
+      <div className="hearing-card-content">
+        <div className="hearing-card-time">
+          {formatRelativeTime("timeClose", hearing.close_at)}
+        </div>
+        <h4 className="hearing-card-title">
+          <Link to={getHearingURL(hearing)}>
+            {getAttr(hearing.title, language)}
+          </Link>
+        </h4>
+        <div className="hearing-card-labels">
+          <LabelList labels={hearing.labels}/>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+HearingCard.propTypes = {
+  hearing: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  language: PropTypes.string
+};
+
+export default HearingCard;

--- a/src/components/HearingCard.js
+++ b/src/components/HearingCard.js
@@ -9,7 +9,7 @@ import {getHearingURL} from '../utils/hearing';
 
 const HearingCard = ({hearing, language}) => {
   const imageStyle = {
-    backgroundImage: hearing.main_image ? `url(${hearing.main_image.url})` : ''
+    backgroundImage: hearing.main_image && hearing.main_image.url ? `url(${hearing.main_image.url})` : ''
   };
   // FIXME: Should there be direct linking to hearing using certain language?
   const translationAvailable = !!getAttr(hearing.title, language/* , {exact: true} */);

--- a/src/components/HearingCard.js
+++ b/src/components/HearingCard.js
@@ -5,18 +5,19 @@ import formatRelativeTime from '../utils/formatRelativeTime';
 import Icon from '../utils/Icon';
 import LabelList from './LabelList';
 import getAttr from '../utils/getAttr';
-import {getHearingURL} from '../utils/hearing';
+import {getHearingURL, getHearingMainImageURL} from '../utils/hearing';
 import moment from 'moment';
 
-const HearingCard = ({hearing, language}) => {
+const HearingCard = ({hearing, language, className = ''}) => {
+  const backgroundImage = getHearingMainImageURL(hearing);
   const imageStyle = {
-    backgroundImage: hearing.main_image && hearing.main_image.url ? `url(${hearing.main_image.url})` : ''
+    backgroundImage: backgroundImage ? `url(${backgroundImage})` : ''
   };
   // FIXME: Should there be direct linking to hearing using certain language?
   const translationAvailable = !!getAttr(hearing.title, language/* , {exact: true} */);
   const expiresSoon = moment(hearing.close_at).diff(moment(), 'weeks') < 1;
   return (
-    <div className="hearing-card">
+    <div className={`hearing-card ${className}`}>
       {
         !translationAvailable &&
         <div className="hearing-card-notice">
@@ -48,6 +49,7 @@ const HearingCard = ({hearing, language}) => {
 };
 
 HearingCard.propTypes = {
+  className: PropTypes.string,
   hearing: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   language: PropTypes.string
 };

--- a/src/components/HearingCardList.js
+++ b/src/components/HearingCardList.js
@@ -1,0 +1,19 @@
+import React, {PropTypes} from 'react';
+import {Row, Col} from 'react-bootstrap';
+import HearingCard from './HearingCard';
+
+const HearingCardList = ({hearings, language}) =>
+  <Row className="hearing-card-list">
+    {hearings && hearings.map((hearing) =>
+      <Col sm={4} key={hearing.id}>
+        <HearingCard hearing={hearing} language={language}/>
+      </Col>
+    )}
+  </Row>;
+
+HearingCardList.propTypes = {
+  hearings: PropTypes.array, // eslint-disable-line react/forbid-prop-types
+  language: PropTypes.string
+};
+
+export default HearingCardList;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -10,7 +10,7 @@
   "table-of-content": "Table of Content",
   "comments": "Comments",
   "overview-map": "Map",
-  "openHearings": "Open hearigns",
+  "openHearings": "Open hearings",
   "infoHeaderText": "About the service",
   "privacyPolicy": "Privacy Policy",
   "lang-fi": "Finnish",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -10,6 +10,7 @@
   "table-of-content": "Table of Content",
   "comments": "Comments",
   "overview-map": "Map",
+  "openHearings": "Open hearigns",
   "infoHeaderText": "About the service",
   "privacyPolicy": "Privacy Policy",
   "lang-fi": "Finnish",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -20,6 +20,7 @@
   "lang-en": "Englanti",
   "lang-sv": "Ruotsi",
   "welcome": "Tervetuloa!",
+  "openHearings": "Avoimet kuulemiset",
   "welcomeMessage": "Kerro mielipiteesi valmisteluun tulevista asioista.",
   "feedbackPrompt": "Kerro meille, miten tätä palvelua pitäisi kehittää!",
   "nextClosingHearing": "Seuraavaksi sulkeutuva kuuleminen",

--- a/src/selectors/hearing.js
+++ b/src/selectors/hearing.js
@@ -3,7 +3,12 @@ import {head} from 'lodash';
 export const getTopHearing = (state) =>
   state.hearingLists.topHearing && state.hearingLists.topHearing.data && head(state.hearingLists.topHearing.data);
 
-export const getOpenHearings = (state) =>
-  state.hearingLists.newestHearings.filter((hearing) => !hearing.closed);
-
-export default '';
+// eslint-disable-next-line
+export const getOpenHearings = ({hearingLists: {newestHearings}}) =>
+  Object.assign(
+    {},
+    newestHearings,
+    newestHearings ? {data: newestHearings.data && newestHearings.data.filter((hearing) =>
+      !hearing.closed && hearing.published
+    )} : {}
+  );

--- a/src/selectors/hearing.js
+++ b/src/selectors/hearing.js
@@ -4,11 +4,5 @@ export const getTopHearing = (state) =>
   state.hearingLists.topHearing && state.hearingLists.topHearing.data && head(state.hearingLists.topHearing.data);
 
 // eslint-disable-next-line
-export const getOpenHearings = ({hearingLists: {newestHearings}}) =>
-  Object.assign(
-    {},
-    newestHearings,
-    newestHearings ? {data: newestHearings.data && newestHearings.data.filter((hearing) =>
-      !hearing.closed && hearing.published
-    )} : {}
-  );
+export const getOpenHearings = (state) =>
+  state.hearingLists.openHearings;

--- a/src/utils/hearing.js
+++ b/src/utils/hearing.js
@@ -28,6 +28,10 @@ export function getHearingURL(hearing, {fullscreen} = {}) {
   return `${url}${query}`;
 }
 
+export function getHearingMainImageURL(hearing) {
+  return _.get(hearing, 'main_image.url');
+}
+
 
 /*
 * Returns true if hearing has a plugin that can be rendered fullscreen

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -5,7 +5,6 @@ import {injectIntl, intlShape, FormattedMessage} from 'react-intl';
 import {connect} from 'react-redux';
 import {fetchHearingList} from '../actions';
 import {getTopHearing, getOpenHearings} from '../selectors/hearing';
-import HearingList from '../components/HearingList';
 import Col from 'react-bootstrap/lib/Col';
 import Row from 'react-bootstrap/lib/Row';
 import FullWidthHearing from '../components//FullWidthHearing';
@@ -22,7 +21,6 @@ class Home extends React.Component {
    */
   static fetchData(dispatch) {
     return Promise.all([
-      dispatch(fetchHearingList("nextClosingHearing", "/v1/hearing/", {next_closing: (new Date().toISOString())})),
       dispatch(fetchHearingList("topHearing", "/v1/hearing", {order: "-n_comments", open: true, limit: 1})),
       dispatch(fetchHearingList("openHearings", "/v1/hearing", {open: true}))
     ]);
@@ -34,7 +32,7 @@ class Home extends React.Component {
 
   render() {
     const {formatMessage} = this.props.intl;
-    const {hearingLists, topHearing, openHearings, language} = this.props;
+    const {topHearing, openHearings, language} = this.props;
     return (<div className="container">
       <Helmet title={formatMessage({id: 'welcome'})}/>
       <h1><FormattedMessage id="welcome"/></h1>
@@ -42,19 +40,6 @@ class Home extends React.Component {
       {topHearing && <FullWidthHearing hearing={topHearing}/>}
       <hr />
       <Row>
-        <Col md={8} xs={12}>
-          <div className="list">
-            <h2 className="page-title"><FormattedMessage id="nextClosingHearing"/></h2>
-            <HearingList hearings={hearingLists.nextClosingHearing} />
-          </div>
-        </Col>
-        <Col md={4} xs={12}>
-          <div className="feedback-box">
-            <a href="mailto:dev@hel.fi?subject=Kerro kantasi -palaute">
-              <h2 className="feedback-prompt"><FormattedMessage id="feedbackPrompt"/></h2>
-            </a>
-          </div>
-        </Col>
         {openHearings && openHearings.state === 'done' &&
           <Col xs={12}>
             <div className="list">
@@ -64,6 +49,13 @@ class Home extends React.Component {
             </div>
           </Col>
         }
+        <Col xs={12}>
+          <div className="feedback-box">
+            <a href="mailto:dev@hel.fi?subject=Kerro kantasi -palaute">
+              <h2 className="feedback-prompt"><FormattedMessage id="feedbackPrompt"/></h2>
+            </a>
+          </div>
+        </Col>
       </Row>
     </div>);
   }
@@ -72,7 +64,6 @@ class Home extends React.Component {
 Home.propTypes = {
   intl: intlShape.isRequired,
   dispatch: React.PropTypes.func,
-  hearingLists: React.PropTypes.object, // eslint-disable-line react/forbid-prop-types
   openHearings: React.PropTypes.object, // eslint-disable-line react/forbid-prop-types
   topHearing: React.PropTypes.object, // eslint-disable-line react/forbid-prop-types
   // eslint-disable-next-line react/no-unused-prop-types
@@ -80,7 +71,6 @@ Home.propTypes = {
 };
 
 const mapStateToProps = (state) => ({
-  hearingLists: state.hearingLists,
   topHearing: getTopHearing(state),
   language: state.language,
   openHearings: getOpenHearings(state)

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Helmet from 'react-helmet';
+import {Link} from 'react-router';
 import {injectIntl, intlShape, FormattedMessage} from 'react-intl';
 import {connect} from 'react-redux';
 import {fetchHearingList} from '../actions';
@@ -50,6 +51,7 @@ class Home extends React.Component {
           <div className="list">
             <h2 className="page-title"><FormattedMessage id="openHearings"/></h2>
             <HearingCardList hearings={orderBy(openHearings.data, ['close_at'], ['desc'])} language={language}/>
+            <Link className="fullwidth" to="/hearings"><FormattedMessage id="allHearings"/></Link>
           </div>
           }
         </Col>

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -47,13 +47,6 @@ class Home extends React.Component {
             <h2 className="page-title"><FormattedMessage id="nextClosingHearing"/></h2>
             <HearingList hearings={hearingLists.nextClosingHearing} />
           </div>
-          {openHearings && openHearings.state === 'done' &&
-          <div className="list">
-            <h2 className="page-title"><FormattedMessage id="openHearings"/></h2>
-            <HearingCardList hearings={orderBy(openHearings.data, ['close_at'], ['desc'])} language={language}/>
-            <Link className="fullwidth" to="/hearings"><FormattedMessage id="allHearings"/></Link>
-          </div>
-          }
         </Col>
         <Col md={4} xs={12}>
           <div className="feedback-box">
@@ -62,6 +55,15 @@ class Home extends React.Component {
             </a>
           </div>
         </Col>
+        {openHearings && openHearings.state === 'done' &&
+          <Col xs={12}>
+            <div className="list">
+              <h2 className="page-title"><FormattedMessage id="openHearings"/></h2>
+              <HearingCardList hearings={orderBy(openHearings.data, ['close_at'], ['desc'])} language={language}/>
+              <Link className="fullwidth" to="/hearings"><FormattedMessage id="allHearings"/></Link>
+            </div>
+          </Col>
+        }
       </Row>
     </div>);
   }

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -21,7 +21,7 @@ class Home extends React.Component {
    */
   static fetchData(dispatch) {
     return Promise.all([
-      dispatch(fetchHearingList("topHearing", "/v1/hearing", {order: "-n_comments", open: true, limit: 1})),
+      dispatch(fetchHearingList("topHearing", "/v1/hearing", {ordering: "-n_comments", open: true, limit: 1})),
       dispatch(fetchHearingList("openHearings", "/v1/hearing", {open: true}))
     ]);
   }

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -3,11 +3,13 @@ import Helmet from 'react-helmet';
 import {injectIntl, intlShape, FormattedMessage} from 'react-intl';
 import {connect} from 'react-redux';
 import {fetchHearingList} from '../actions';
-import {getTopHearing} from '../selectors/hearing';
+import {getTopHearing, getOpenHearings} from '../selectors/hearing';
 import HearingList from '../components/HearingList';
 import Col from 'react-bootstrap/lib/Col';
 import Row from 'react-bootstrap/lib/Row';
 import FullWidthHearing from '../components//FullWidthHearing';
+import HearingCardList from '../components/HearingCardList';
+import orderBy from 'lodash/orderBy';
 
 class Home extends React.Component {
   /**
@@ -31,7 +33,7 @@ class Home extends React.Component {
 
   render() {
     const {formatMessage} = this.props.intl;
-    const {hearingLists, topHearing} = this.props;
+    const {hearingLists, topHearing, openHearings, language} = this.props;
     return (<div className="container">
       <Helmet title={formatMessage({id: 'welcome'})}/>
       <h1><FormattedMessage id="welcome"/></h1>
@@ -44,10 +46,12 @@ class Home extends React.Component {
             <h2 className="page-title"><FormattedMessage id="nextClosingHearing"/></h2>
             <HearingList hearings={hearingLists.nextClosingHearing} />
           </div>
+          {openHearings.state === 'done' &&
           <div className="list">
-            <h2 className="page-title"><FormattedMessage id="newestHearings"/></h2>
-            <HearingList hearings={hearingLists.newestHearings} />
+            <h2 className="page-title"><FormattedMessage id="openHearings"/></h2>
+            <HearingCardList hearings={orderBy(openHearings.data, ['close_at'], ['desc'])} language={language}/>
           </div>
+          }
         </Col>
         <Col md={4} xs={12}>
           <div className="feedback-box">
@@ -65,6 +69,7 @@ Home.propTypes = {
   intl: intlShape.isRequired,
   dispatch: React.PropTypes.func,
   hearingLists: React.PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  openHearings: React.PropTypes.object, // eslint-disable-line react/forbid-prop-types
   topHearing: React.PropTypes.object, // eslint-disable-line react/forbid-prop-types
   // eslint-disable-next-line react/no-unused-prop-types
   language: React.PropTypes.string, // make sure changing language refreshes
@@ -74,6 +79,7 @@ const mapStateToProps = (state) => ({
   hearingLists: state.hearingLists,
   topHearing: getTopHearing(state),
   language: state.language,
+  openHearings: getOpenHearings(state)
 });
 
 const WrappedHome = connect(mapStateToProps)(injectIntl(Home));

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -22,8 +22,8 @@ class Home extends React.Component {
   static fetchData(dispatch) {
     return Promise.all([
       dispatch(fetchHearingList("nextClosingHearing", "/v1/hearing/", {next_closing: (new Date().toISOString())})),
-      dispatch(fetchHearingList("newestHearings", "/v1/hearing/", {order: "-created_at"})),
-      dispatch(fetchHearingList("topHearing", "/v1/hearing", {order: "-n_comments", open: true, limit: 1}))
+      dispatch(fetchHearingList("topHearing", "/v1/hearing", {order: "-n_comments", open: true, limit: 1})),
+      dispatch(fetchHearingList("openHearings", "/v1/hearing", {open: true}))
     ]);
   }
 
@@ -46,7 +46,7 @@ class Home extends React.Component {
             <h2 className="page-title"><FormattedMessage id="nextClosingHearing"/></h2>
             <HearingList hearings={hearingLists.nextClosingHearing} />
           </div>
-          {openHearings.state === 'done' &&
+          {openHearings && openHearings.state === 'done' &&
           <div className="list">
             <h2 className="page-title"><FormattedMessage id="openHearings"/></h2>
             <HearingCardList hearings={orderBy(openHearings.data, ['close_at'], ['desc'])} language={language}/>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3671,6 +3671,10 @@ moment@2.x.x:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.17.0.tgz#a4c292e02aac5ddefb29a6eed24f51938dd3b74f"
 
+moment@^2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.17.1.tgz#fed9506063f36b10f066c8b59a144d7faebe1d82"
+
 morgan@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.7.0.tgz#eb10ca8e50d1abe0f8d3dad5c0201d052d981c62"


### PR DESCRIPTION
Fixes #254.

Note: Direct linking to hearings in certain languages is still missing. I wouldn't start implementing that before the API has the translations.

- [x] Highlight expiring hearings
- [x] Card images as clickable links