### PR TITLE
Hearing manager improvements

### DIFF
--- a/assets/sass/hel/hearing-form.scss
+++ b/assets/sass/hel/hearing-form.scss
@@ -90,7 +90,7 @@ $node_modules: "../../../node_modules";
 }
 
 .toolbar-bottom {
-    background: gray-light;
+    background: $light-gray;
     bottom: 0;
     box-shadow: 0 0 4px rgba(0,0,0,.2);
     left: 0;
@@ -98,10 +98,14 @@ $node_modules: "../../../node_modules";
     position: fixed;
     text-align: center;
     width: 100%;
-    z-index: 10;
+    z-index: 1002;
 
     .status-label {
         font-weight: bold;
         font-size: 27px;
+    }
+
+    .btn.btn-default {
+      background: #fff;
     }
 }

--- a/src/components/admin/HearingFormStep2.js
+++ b/src/components/admin/HearingFormStep2.js
@@ -11,7 +11,7 @@ import SectionForm from './SectionForm';
 import {addSection, removeSection} from '../../actions/hearingEditor';
 import {getMainSection} from '../../utils/hearing';
 import {hearingShape} from '../../types';
-import {initNewSection} from '../../utils/section';
+import {initNewSection, SectionTypes} from '../../utils/section';
 import getAttr from '../../utils/getAttr';
 
 class HearingFormStep2 extends React.Component {
@@ -48,28 +48,30 @@ class HearingFormStep2 extends React.Component {
   getSections() {
     const {language} = this.context;
     const {hearingLanguages} = this.props;
-    return this.props.hearing.sections.map((section) => {
-      const sectionHeader = this.props.intl.formatMessage({
-        id: `${section.type}Section`
+    return this.props.hearing.sections
+      .filter(({type}) => type !== SectionTypes.CLOSURE)
+      .map((section) => {
+        const sectionHeader = this.props.intl.formatMessage({
+          id: `${section.type}Section`
+        });
+        const sectionID = section.id || "";
+        return (
+          <Panel
+            eventKey={sectionID}
+            header={`${sectionHeader}: ${getAttr(section.title, language) || ''}`}
+            key={sectionID}
+          >
+            <SectionForm
+              section={section}
+              onSectionChange={this.props.onSectionChange}
+              onSectionImageChange={this.props.onSectionImageChange}
+              sectionLanguages={hearingLanguages}
+            />
+            <hr/>
+            {this.getDeleteSectionButton(section, sectionID)}
+          </Panel>
+        );
       });
-      const sectionID = section.id || section.frontID || "";
-      return (
-        <Panel
-          eventKey={sectionID}
-          header={`${sectionHeader}: ${getAttr(section.title, language)}`}
-          key={sectionID}
-        >
-          <SectionForm
-            section={section}
-            onSectionChange={this.props.onSectionChange}
-            onSectionImageChange={this.props.onSectionImageChange}
-            sectionLanguages={hearingLanguages}
-          />
-          <hr/>
-          {this.getDeleteSectionButton(section, sectionID)}
-        </Panel>
-      );
-    });
   }
 
   handleSelect(activeSection) {
@@ -82,10 +84,9 @@ class HearingFormStep2 extends React.Component {
    */
   addSection(type) {
     const newSection = initNewSection();
-    newSection.frontID = (this.sectionSequence += 1).toString();
     newSection.type = type;
     this.props.dispatch(addSection(newSection));
-    this.setState({activeSection: newSection.frontID});
+    this.setState({activeSection: newSection.id});
   }
 
   /*

--- a/src/components/admin/HearingFormStep4.js
+++ b/src/components/admin/HearingFormStep4.js
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import React from 'react';
+import {connect} from 'react-redux';
 import {injectIntl, FormattedMessage} from 'react-intl';
 
 import Col from 'react-bootstrap/lib/Col';
@@ -13,6 +14,7 @@ import {getClosureSection} from '../../utils/hearing';
 import {initNewSection, SectionTypes} from '../../utils/section';
 import MultiLanguageTextField, {TextFieldTypes} from '../forms/MultiLanguageTextField';
 import {hearingShape} from '../../types';
+import {addSection} from '../../actions/hearingEditor';
 
 
 class HearingFormStep4 extends React.Component {
@@ -24,23 +26,18 @@ class HearingFormStep4 extends React.Component {
     this.time_format = "";
     this.onChangeStart = this.onChangeStart.bind(this);
     this.onChangeEnd = this.onChangeEnd.bind(this);
-    this.onChange = this.onChange.bind(this);
+    this.onClosureSectionChange = this.onClosureSectionChange.bind(this);
     moment.locale("fi-FI");
   }
 
-  onChange(event) {
-    if (this.props.onHearingChange) {
-      // Propagate interestin changes to parent components
-      const {name: field, value} = event.target;
-      switch (field) {
-        case "closureInfo": {
-          const closureInfoSection = getClosureSection(this.props.hearing) || {};
-          this.props.onSectionChange(closureInfoSection.id, "content", value);
-          break;
-        }
-        default:
-          this.props.onHearingChange(field, value);
-      }
+  onClosureSectionChange(value) {
+    const {hearing, onSectionChange, dispatch} = this.props;
+    const closureInfoSection = getClosureSection(hearing);
+
+    if (closureInfoSection) {
+      onSectionChange(closureInfoSection.id, 'content', value);
+    } else {
+      dispatch(addSection(initNewSection({type: SectionTypes.CLOSURE, content: value})));
     }
   }
 
@@ -61,7 +58,7 @@ class HearingFormStep4 extends React.Component {
   }
 
   render() {
-    const {hearing, hearingLanguages, onSectionChange} = this.props;
+    const {hearing, hearingLanguages} = this.props;
     const closureInfoSection = getClosureSection(hearing) || initNewSection({type: SectionTypes.CLOSURE});
 
     return (
@@ -96,7 +93,7 @@ class HearingFormStep4 extends React.Component {
         <MultiLanguageTextField
           labelId="hearingClosureInfo"
           name="closureInfo"
-          onBlur={(value) => onSectionChange(closureInfoSection.id, 'content', value)}
+          onBlur={this.onClosureSectionChange}
           rows="10"
           value={closureInfoSection.content}
           fieldType={TextFieldTypes.TEXTAREA}
@@ -108,17 +105,14 @@ class HearingFormStep4 extends React.Component {
   }
 }
 
-HearingFormStep4.defaultProps = {
-  onChange: () => {}
-};
-
 HearingFormStep4.propTypes = {
+  dispatch: React.PropTypes.func,
   hearing: hearingShape,
   onHearingChange: React.PropTypes.func,
   onSectionChange: React.PropTypes.func,
   hearingLanguages: React.PropTypes.arrayOf(React.PropTypes.string),
 };
 
-const WrappedHearingFormStep4 = injectIntl(HearingFormStep4);
+const WrappedHearingFormStep4 = connect()(injectIntl(HearingFormStep4));
 
 export default WrappedHearingFormStep4;

--- a/src/utils/hearing.js
+++ b/src/utils/hearing.js
@@ -97,7 +97,9 @@ Return initialized Hearing object representation.
  */
 export function initNewHearing(inits) {
   const mainSection = initNewSection();
-  mainSection.type = "main";
+  mainSection.type = SectionTypes.MAIN;
+  const closureSection = initNewSection();
+  closureSection.type = SectionTypes.CLOSURE;
   return _.merge({
     abstract: initAttr(),
     title: initAttr(),
@@ -106,7 +108,7 @@ export function initNewHearing(inits) {
     published: false,
     open_at: null,
     close_at: null,
-    sections: [mainSection],
+    sections: [mainSection, closureSection],
     main_image: {},
     contact_persons: [],
     n_comments: 0,


### PR DESCRIPTION
> Therefore, closureInfo should not be shown at all in Form step 2 under hearing sections.

✅

> When adding a new Section, it should open up expanded, while collapsing the previous section that the user was working on.

✅

* Fix adding closure info section to hearing ✅
* Fix bottom toolbar styles ✅

