### PR TITLE
Some finishes to the simple text editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "history": "^1.13.0",
     "html-loader": "^0.4.0",
     "immutability-helper": "^2.2.3",
+    "immutable": "^3.7.6",
     "intl": "^1.1.0",
     "isomorphic-fetch": "^2.2.0",
     "json-loader": "^0.5.3",

--- a/src/components/RichTextEditor/EditorControls.js
+++ b/src/components/RichTextEditor/EditorControls.js
@@ -2,18 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const BLOCK_TYPES = [
-  {label: 'H2', style: 'header-two'},
-  {label: 'H3', style: 'header-three'},
-  {label: 'H4', style: 'header-four'},
-  {label: 'Blockquote', style: 'blockquote'},
-  {label: 'UL', style: 'unordered-list-item'},
-  {label: 'OL', style: 'ordered-list-item'},
+  {label: 'Väliotsikko', style: 'header-four'},
+  {label: 'Lista', style: 'unordered-list-item'},
+  {label: 'Numeroitu lista', style: 'ordered-list-item'},
 ];
 
 const INLINE_STYLES = [
-  {label: 'Bold', style: 'BOLD'},
-  {label: 'Italic', style: 'ITALIC'},
-  {label: 'Underline', style: 'UNDERLINE'},
+  {label: 'Lihavointi', style: 'BOLD'},
 ];
 
 class StyleButton extends React.Component {

--- a/src/components/RichTextEditor/index.js
+++ b/src/components/RichTextEditor/index.js
@@ -8,9 +8,11 @@ import {
   ContentState,
   CompositeDecorator,
   RichUtils,
-  convertFromHTML
+  convertFromHTML,
+  DefaultDraftBlockRenderMap,
 } from 'draft-js';
 import { stateToHTML } from 'draft-js-export-html';
+import { Map } from 'immutable';
 
 import { BlockStyleControls, InlineStyleControls } from './EditorControls';
 
@@ -20,6 +22,14 @@ const getBlockStyle = (block) => {
     default: return null;
   }
 };
+
+const kerrokantasiBlockRenderMap = Map({
+  unstyled: {
+    element: 'p',
+  }
+});
+
+const blockRenderMap = DefaultDraftBlockRenderMap.merge(kerrokantasiBlockRenderMap);
 
 const findLinkEntities = (contentBlock, callback, contentState) => {
   contentBlock.findEntityRanges(
@@ -221,7 +231,7 @@ class RichTextEditor extends React.Component {
             onChange={this.onURLChange}
           />
           <span className="RichEditor-styleButton" onMouseDown={this.confirmLink}>
-            Confirm
+            OK
           </span>
         </div>
       );
@@ -231,10 +241,10 @@ class RichTextEditor extends React.Component {
       <div className="hyperlink-button">
         <div>
           <span className="RichEditor-styleButton" onMouseDown={this.promptForLink}>
-            Add Link
+            Lisää linkki
           </span>
           <span className="RichEditor-styleButton" onMouseDown={this.removeLink}>
-            Remove Link
+            Poista linkki
           </span>
         </div>
         {urlInput}
@@ -262,6 +272,7 @@ class RichTextEditor extends React.Component {
         <Editor
           ref="editor"
           blockStyleFn={getBlockStyle}
+          blockRenderMap={blockRenderMap}
           editorState={editorState}
           handleKeyCommand={this.handleKeyCommand}
           onChange={this.onChange}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2791,7 +2791,7 @@ immutability-helper@^2.2.3:
   dependencies:
     invariant "^2.2.0"
 
-immutable@~3.7.4:
+immutable@^3.7.6, immutable@~3.7.4:
   version "3.7.6"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
 


### PR DESCRIPTION
Removed the formatting tags that are not currently used in hearings. Better keep it simple and just give the user the bare minimum options in creating a hearing. Feel free to point out any required formatting options not present.

One problem here is that `lead` class paragraphs with a separate styling (as used in most hearings) cannot currently be implemented with draft.js, as it strips any class names from the html when parsing it. Made an issue #401 about it, don't know what to do about it at present. Any suggestions on how to format and structure a hearing without css styling are most welcome.