### PR TITLE
Remove Node 4.2 from tested configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "4.2"
   - "lts/*"
   - "node"
 


### PR DESCRIPTION
Node 4.2 is not current by any means anymore.