### PR TITLE
Feature/#316&#210

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -96,7 +96,10 @@ export function fetchHearing(hearingSlug, previewKey = null) {
     const params = previewKey ? {preview: previewKey} : {};
     return api.get(getState(), url, params).then(getResponseJSON).then((data) => {
       dispatch(createAction("receiveHearing")({hearingSlug, data}));
-    }).catch(requestErrorHandler());
+    }).catch(() => {
+      dispatch(createAction("receiveHearingError")({hearingSlug}));
+      requestErrorHandler();
+    });
     // FIXME: Somehow .catch catches errors also from components' render methods
   };
 }

--- a/src/components/Hearing.js
+++ b/src/components/Hearing.js
@@ -250,7 +250,7 @@ export class Hearing extends React.Component {
                 dangerouslySetInnerHTML={{__html: getAttr(hearing.abstract, language)}}
               />
 
-              {hearing.closed ? (
+              {hearing.closed && hearing.published ? (
                 <WrappedSection
                   fetchAllComments={this.props.fetchAllComments}
                   section={closureInfoSection}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -121,5 +121,6 @@
   "createHearing": "Create new hearing",
   "createLabel": "Create a new tag",
   "labelPlaceholder": "Name of tag here...",
-  "draftNotPublished": "Draft, not published"
+  "draftNotPublished": "Draft, not published",
+  "hearingNotFound": "Hearing was not found."
 }

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -176,5 +176,6 @@
   "createHearing": "Luo uusi kuuleminen",
   "createLabel": "Luo uusi tagi",
   "labelPlaceholder": "Anna tagin nimi...",
-  "draftNotPublished": "Luonnos, ei julkaistu"
+  "draftNotPublished": "Luonnos, ei julkaistu",
+  "hearingNotFound": "Hakemaasi kuulemista ei löytynyt."
 }

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -114,5 +114,6 @@
   "alreadyVoted": "Du har redan röstat för denna kommentar.",
   "voteReceived": "Rösten mottagen. Tack!",
   "createLabel": "TODO",
-  "labelPlaceholder": "TODO"
+  "labelPlaceholder": "TODO",
+  "hearingNotFound": "Hörandet kunde inte hittas."
 }

--- a/src/reducers/hearing.js
+++ b/src/reducers/hearing.js
@@ -23,6 +23,12 @@ const receiveHearing = (state, {payload}) => {
   }, state);
 };
 
+const receiveHearingError = (state, {payload}) => {
+  return updeep({
+    [payload.hearingSlug]: {state: "error"}
+  }, state);
+};
+
 const savedHearing = (state, {payload: {hearing}}) => {
   return updeep({
     [hearing.slug]: {state: 'done', data: hearing}
@@ -56,6 +62,7 @@ const clearNonPublicHearings = (state) => {
 export default handleActions({
   beginFetchHearing,
   receiveHearing,
+  receiveHearingError,
   changeCurrentlyViewed,
   savedHearingChange,
   savedNewHearing: savedHearingChange,

--- a/src/reducers/hearingEditor/hearing.js
+++ b/src/reducers/hearingEditor/hearing.js
@@ -40,6 +40,7 @@ const isFetching = handleActions(
   {
     [combineActions('beginFetchHearing')]: () => true,
     [combineActions('receiveHearing')]: () => false,
+    [combineActions('receiveHearingError')]: () => false
   },
   false,
 );

--- a/src/reducers/hearingEditor/index.js
+++ b/src/reducers/hearingEditor/index.js
@@ -16,6 +16,7 @@ const showEditor = handleActions({
 const editorPending = handleActions({
   beginFetchHearing: (state) => state + 1,
   receiveHearing: (state) => state - 1,
+  receiveHearingError: (state) => state - 1,
   [EditorActions.FETCH_META_DATA]: (state) => state + 1,
   [EditorActions.RECEIVE_META_DATA]: (state) => state - 1,
 }, 0);

--- a/src/views/Hearing/index.js
+++ b/src/views/Hearing/index.js
@@ -10,7 +10,7 @@ import { initNewHearing, fetchHearingEditorMetaData } from '../../actions/hearin
 import { getMainSection, canEdit, getHearingURL, getOpenGraphMetaData } from '../../utils/hearing';
 import HearingEditor from '../../components/admin/HearingEditor';
 import { contactShape, hearingShape, labelShape } from '../../types';
-import { injectIntl, intlShape } from 'react-intl';
+import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
 import { getUser } from '../../selectors/user';
 import { withRouter } from 'react-router-dom';
 import * as HearingEditorSelector from '../../selectors/hearingEditor';
@@ -176,11 +176,19 @@ export class HearingView extends React.Component {
     } = this.props;
     const fullscreen = this.checkNeedForFullscreen();
     const HearingComponent = fullscreen ? FullscreenHearing : DefaultHearingComponent;
+    const hearingState = this.props.hearing[params.hearingSlug] ? this.props.hearing[params.hearingSlug].state : '';
     if (!this.state.manager) {
       // this is the standard hearing view with no wrappers around it
-      if (!hearing) {
+      if (!hearing && hearingState !== 'error') {
         return this.renderSpinner();
       }
+      if (hearingState === 'error') {
+        return (
+          <div className="closure-info">
+            <FormattedMessage id="hearingNotFound" />
+          </div>);
+      }
+
       return (
         <div key="hearing" className={fullscreen ? 'fullscreen-hearing' : 'container'}>
           <Helmet title={getAttr(hearing.title, language)} meta={getOpenGraphMetaData(hearing, language)} />

--- a/src/views/Hearings/index.js
+++ b/src/views/Hearings/index.js
@@ -140,7 +140,7 @@ class Hearings extends React.Component {
   }
 
   setAdminFilter(filter) {
-    this.setState(() => ({ adminFilter: filter }));
+    this.setState({ adminFilter: filter }, () => this.fetchHearingList());
   }
 
   fetchHearingList(props = this.props) {


### PR DESCRIPTION
Solves #316 & #210 #450 .

Contains a small bug (feature): when refreshing hearing draft page and fetching the hearing, API will return 404 as there is no user thus no token yet. This will quickly flash 404 message to the user instead of spinner. After receiving the token the hearing will be fetched again and the message will disappear.

It can't be solved by fetching after we have the token, as there is no possibility to know this is a draft. In finished hearings we need to fetch anyway, even without logging in. Also we can't replace the message with another for the same exact reason.

I don't think this is game breaking as the case is somewhat borderline. Usually the page will be entered via hearing list thus the problem won't occure and even when it does it is only for a very brief moment.