### PR TITLE
Style hearing header to have full width bg

### DIFF
--- a/assets/sass/hel/carousel.scss
+++ b/assets/sass/hel/carousel.scss
@@ -1,9 +1,6 @@
 .carousel-container {
-  margin: 0 auto;
-  padding: 20px 20px;
+  margin: 0 auto $line-height-computed * 2;
   width: 100%;
-  color: #333;
-  background: #ebedf1;
   margin-bottom: 20px;
   display: flex;
   flex-direction: row;

--- a/assets/sass/hel/hearing-page.scss
+++ b/assets/sass/hel/hearing-page.scss
@@ -1,5 +1,10 @@
-.hearing-wrapper {
-  margin-top: $line-height-computed * 1;
+.header-section {
+  background-color: $hel-silver;
+  padding-top: $line-height-computed * 2;
+}
+
+.hearing-content-section {
+  padding-top: $line-height-computed * 2;
 }
 
 .hearing-sidebar {

--- a/src/components/Hearing.js
+++ b/src/components/Hearing.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 // import { push } from 'redux-router';
-import { Button, Col, Row, Tooltip } from 'react-bootstrap';
+import { Button, Col, Row, Tooltip, Grid } from 'react-bootstrap';
 import DeleteModal from './DeleteModal';
 import {injectIntl, intlShape, FormattedMessage} from 'react-intl';
 import ContactCard from './ContactCard';
@@ -253,61 +253,69 @@ export class Hearing extends React.Component {
 
     return (
       <div className="hearing-wrapper" id="hearing-wrapper">
-        <Header hearing={hearing} reportUrl={reportUrl} activeLanguage={language} eyeTooltip={eyeTooltip} />
-        <WrappedCarousel hearing={hearing} />
-        <Row>
-          <Col lg={12}>
-            <div id="hearing" className="hearing-content">
-              <Waypoint onEnter={() => changeCurrentlyViewed('#hearing')} topOffset={'-30%'} />
-              <HearingImageList images={mainSection.images} />
-              <div
-                className="hearing-abstract lead"
-                dangerouslySetInnerHTML={{__html: getAttr(hearing.abstract, language)}}
-              />
+        <div className="header-section">
+          <Grid>
+            <Header hearing={hearing} reportUrl={reportUrl} activeLanguage={language} eyeTooltip={eyeTooltip} />
+            <WrappedCarousel hearing={hearing} />
+          </Grid>
+        </div>
+        <div className="hearing-content-section">
+          <Grid>
+            <Row>
+              <Col md={8} mdOffset={2}>
+                <div id="hearing" className="hearing-content">
+                  <Waypoint onEnter={() => changeCurrentlyViewed('#hearing')} topOffset={'-30%'} />
+                  <HearingImageList images={mainSection.images} />
+                  <div
+                    className="hearing-abstract lead"
+                    dangerouslySetInnerHTML={{__html: getAttr(hearing.abstract, language)}}
+                  />
 
-              {hearing.closed && hearing.published ? (
-                <WrappedClosureInfo closureInfo={getAttr(closureInfoSection.content)} />
-              ) : null}
-              {mainSection ? (
-                <WrappedSection
-                  sectionNav={sectionNav}
-                  hearingSlug={hearing.slug}
-                  showPlugin={showPluginInline}
-                  section={mainSection}
-                  canComment={this.isMainSectionCommentable(hearing, user)}
-                  onPostComment={this.onPostSectionComment.bind(this)}
-                  onPostVote={this.onVoteComment.bind(this)}
-                  canVote={this.isMainSectionVotable(user)}
-                  comments={this.props.sectionComments[mainSection.id]}
-                  user={user}
-                  fetchAllComments={this.props.fetchAllComments}
-                />
-              ) : null}
-            </div>
-            <div className="hearing-contacts">
-              {hearing.contact_persons && hearing.contact_persons.length ? (
-                <h3>
-                  <FormattedMessage id="contactPersons" />
-                </h3>
-              ) : null}
-              <Row>
-                {hearing.contact_persons &&
-                  hearing.contact_persons.map((person, index) => (
-                    <Col
-                      xs={6}
-                      key={index} // eslint-disable-line react/no-array-index-key
-                      md={4}
-                    >
-                      <ContactCard activeLanguage={language} {...person} />
-                    </Col>
-                  ))}
-              </Row>
-            </div>
-            {this.getLinkToFullscreen(hearing)}
-            <Waypoint onEnter={() => changeCurrentlyViewed('#hearing-comments')} topOffset={'-600px'} />
-            {this.getCommentList()}
-          </Col>
-        </Row>
+                  {hearing.closed && hearing.published ? (
+                    <WrappedClosureInfo closureInfo={getAttr(closureInfoSection.content)} />
+                  ) : null}
+                  {mainSection ? (
+                    <WrappedSection
+                      sectionNav={sectionNav}
+                      hearingSlug={hearing.slug}
+                      showPlugin={showPluginInline}
+                      section={mainSection}
+                      canComment={this.isMainSectionCommentable(hearing, user)}
+                      onPostComment={this.onPostSectionComment.bind(this)}
+                      onPostVote={this.onVoteComment.bind(this)}
+                      canVote={this.isMainSectionVotable(user)}
+                      comments={this.props.sectionComments[mainSection.id]}
+                      user={user}
+                      fetchAllComments={this.props.fetchAllComments}
+                    />
+                  ) : null}
+                </div>
+                <div className="hearing-contacts">
+                  {hearing.contact_persons && hearing.contact_persons.length ? (
+                    <h3>
+                      <FormattedMessage id="contactPersons" />
+                    </h3>
+                  ) : null}
+                  <Row>
+                    {hearing.contact_persons &&
+                      hearing.contact_persons.map((person, index) => (
+                        <Col
+                          xs={6}
+                          key={index} // eslint-disable-line react/no-array-index-key
+                          md={4}
+                        >
+                          <ContactCard activeLanguage={language} {...person} />
+                        </Col>
+                      ))}
+                  </Row>
+                </div>
+                {this.getLinkToFullscreen(hearing)}
+                <Waypoint onEnter={() => changeCurrentlyViewed('#hearing-comments')} topOffset={'-600px'} />
+                {this.getCommentList()}
+              </Col>
+            </Row>
+          </Grid>
+        </div>
         <DeleteModal
           isOpen={this.state.showDeleteModal}
           close={this.closeDeleteModal.bind(this)}

--- a/src/components/SectionContainer.js
+++ b/src/components/SectionContainer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import {Button, Row, Col} from 'react-bootstrap';
+import {Button, Row, Col, Grid} from 'react-bootstrap';
 import {injectIntl, intlShape, FormattedMessage} from 'react-intl';
 import WrappedCarousel from '../components/Carousel';
 import DeleteModal from './DeleteModal';
@@ -151,35 +151,43 @@ export class SectionContainer extends React.Component {
     const showPluginInline = Boolean(!section.plugin_fullscreen && section.plugin_identifier);
     // const fullscreenMapPlugin = hasFullscreenMapPlugin(hearing);
     return (
-      <div className="hearing-wrapper section-container">
-        <div className="text-right">{this.getFollowButton()}</div>
-        <Header hearing={hearing} activeLanguage={language} />
-        <WrappedCarousel language={language} hearing={hearing} />
-        <Row>
-          <Col md={12} lg={12}>
-            {hearing.closed ? <WrappedClosureInfo closureInfo={getAttr(closureInfoSection.content, language)} /> : null}
-            <WrappedSection
-              isQuestionView
-              section={section}
-              hearingSlug={hearingSlug}
-              canComment={isSectionCommentable(hearing, section, user)}
-              onPostComment={this.onPostSectionComment.bind(this)} // this.props.onPostComment}
-              canVote={isSectionVotable(hearing, section, user)} // this.props.canVote && userCanVote(user, section)}
-              onPostVote={this.onVoteComment.bind(this)} // this.props.onPostVote}
-              comments={sectionComments} // this.props.loadSectionComments}
-              handleDeleteClick={this.handleDeleteClick.bind(this)}
-              onEditComment={this.onEditSectionComment.bind(this)}
-              user={user}
-              isCollapsible={false}
-              showPlugin={showPluginInline}
-              fetchAllComments={this.props.fetchAllComments}
-              fetchCommentsForSortableList={this.props.fetchCommentsForSortableList}
-              fetchMoreComments={this.props.fetchMoreComments}
-              sectionNav={sectionNav}
-              hearingUrl={getHearingURL(hearing)}
-            />
-          </Col>
-        </Row>
+      <div className="hearing-wrapper">
+        <div className="header-section">
+          <Grid>
+            <div className="text-right">{this.getFollowButton()}</div>
+            <Header hearing={hearing} activeLanguage={language} />
+            <WrappedCarousel language={language} hearing={hearing} />
+          </Grid>
+        </div>
+        <div className="hearing-content-section">
+          <Grid>
+            <Row>
+              <Col md={8} mdOffset={2}>
+                {hearing.closed ? <WrappedClosureInfo closureInfo={getAttr(closureInfoSection.content, language)} /> : null}
+                <WrappedSection
+                  isQuestionView
+                  section={section}
+                  hearingSlug={hearingSlug}
+                  canComment={isSectionCommentable(hearing, section, user)}
+                  onPostComment={this.onPostSectionComment.bind(this)} // this.props.onPostComment}
+                  canVote={isSectionVotable(hearing, section, user)} // this.props.canVote && userCanVote(user, section)}
+                  onPostVote={this.onVoteComment.bind(this)} // this.props.onPostVote}
+                  comments={sectionComments} // this.props.loadSectionComments}
+                  handleDeleteClick={this.handleDeleteClick.bind(this)}
+                  onEditComment={this.onEditSectionComment.bind(this)}
+                  user={user}
+                  isCollapsible={false}
+                  showPlugin={showPluginInline}
+                  fetchAllComments={this.props.fetchAllComments}
+                  fetchCommentsForSortableList={this.props.fetchCommentsForSortableList}
+                  fetchMoreComments={this.props.fetchMoreComments}
+                  sectionNav={sectionNav}
+                  hearingUrl={getHearingURL(hearing)}
+                />
+              </Col>
+            </Row>
+          </Grid>
+        </div>
         <DeleteModal
           isOpen={this.state.showDeleteModal}
           close={this.closeDeleteModal.bind(this)}

--- a/src/views/Hearing/Header.js
+++ b/src/views/Hearing/Header.js
@@ -32,7 +32,7 @@ class Header extends React.Component {
   render() {
     const { hearing, activeLanguage, reportUrl, eyeTooltip } = this.props;
     return (
-      <div className="hearing-header well">
+      <div className="hearing-header">
         <h1>
           {!isPublic(hearing)
             ? <OverlayTrigger placement="bottom" overlay={eyeTooltip}><Icon name="eye-slash"/></OverlayTrigger>

--- a/src/views/Hearing/index.js
+++ b/src/views/Hearing/index.js
@@ -127,7 +127,7 @@ export class HearingView extends React.Component {
   // eslint-disable-next-line class-methods-use-this
   renderSpinner() {
     return (
-      <div className="container">
+      <div className="hearing-page">
         <LoadSpinner />
       </div>
     );
@@ -190,7 +190,7 @@ export class HearingView extends React.Component {
       }
 
       return (
-        <div key="hearing" className={fullscreen ? 'fullscreen-hearing' : 'container'}>
+        <div key="hearing" className={fullscreen ? 'fullscreen-hearing' : 'hearing-page'}>
           <Helmet title={getAttr(hearing.title, language)} meta={getOpenGraphMetaData(hearing, language)} />
           <HearingComponent
             hearingSlug={params.hearingSlug}
@@ -209,7 +209,7 @@ export class HearingView extends React.Component {
     // this is the manager
     if (!user) {
       return (
-        <div className="container">
+        <div className="hearing-page">
           <PleaseLogin login={() => dispatch(login())} />
         </div>
       );
@@ -217,7 +217,7 @@ export class HearingView extends React.Component {
 
     if (!hearingDraft) {
       return (
-        <div className="container">
+        <div className="hearing-page">
           <this.renderSpinner />
         </div>
       );
@@ -244,7 +244,7 @@ export class HearingView extends React.Component {
 
 
     return (
-      <div className="container">
+      <div className="hearing-page">
         <Helmet title={getAttr(hearingDraft.title, language)} meta={getOpenGraphMetaData(hearingDraft, language)} />
 
         <HearingEditor

--- a/src/views/QuestionView.js
+++ b/src/views/QuestionView.js
@@ -71,7 +71,7 @@ export class QuestionView extends Component {
     }
 
     return (
-      <div key="question" className="question-view container">
+      <div key="question" className="question-view">
         <Helmet title={getAttr(hearing.title, language)} meta={getOpenGraphMetaData(hearing, language)} />
         <WrappedSectionContainer
           hearingSlug={hearingSlug}


### PR DESCRIPTION
Removed a lot of `container` -wrappers. In general the page could constitute of stacked full browser width sections (that can have a full width background color) and then the content can add a `class="container" or <Grid>` wrapper to limit the content width within the section.