### PR TITLE
Fix scrolling issue when routes are changed

### DIFF
--- a/src/getRoot.js
+++ b/src/getRoot.js
@@ -3,13 +3,16 @@ import {Provider} from 'react-redux';
 import {ConnectedRouter} from 'react-router-redux';
 import App from './App';
 import {history} from './createStore';
+import ScrollToTop from './scrollToTop';
 
 export default function getRoot(store) {
   return (
     <div>
       <Provider store={store}>
         <ConnectedRouter history={history}>
-          <App />
+          <ScrollToTop>
+            <App />
+          </ScrollToTop>
         </ConnectedRouter>
       </Provider>
     </div>

--- a/src/scrollToTop.js
+++ b/src/scrollToTop.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router-dom';
+
+class ScrollToTop extends React.Component {
+  componentDidUpdate(prevProps) {
+    if (this.props.location.pathname !== prevProps.location.pathname) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+ScrollToTop.propTypes = {
+  children: PropTypes.object,
+  location: PropTypes.object,
+  pathname: PropTypes.string,
+};
+
+export default withRouter(ScrollToTop);


### PR DESCRIPTION
Currently the page does not scroll to the top if a page gets
changed. If the user has scrolled down and clicks e.g. navigation
links, the page will stay scrolled down at the point where user
was.

This is a fix to scroll up when using routes to go to a new page.

Found the solution from here:
https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/guides/scroll-restoration.md