### PR TITLE
Fix some of the image alt texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ can also directly run `server(/index.js)`.
 
 * `yarn run fetch-plugins`: fetch optional plugins (see below)
 * `yarn run test`: run tests
+* `yarn test -- -u` update tests
 
 ### Plugins
 
@@ -167,7 +168,7 @@ work.
 * `/assets/app.scss`: The base style file that is imported
 * `/i18n/[fi, sv, en].json`: Language files. If no string changes are to be made, only include `{}` in the files
 * `/i18n/localization.json`: Other configuration related to localization. Currently holds map default position
-* `/i18n/service-info/content.[fi, sv, en].md`: Service info page texts, if no file found service will display 
+* `/i18n/service-info/content.[fi, sv, en].md`: Service info page texts, if no file found service will display
 information that content was not found.
 * `/assets/images/logo[fi, sv]-black.svg`: Black/Dark site logo
 * `/assets/images/logo[fi, sv]-white.svg`: White/Light site logo

--- a/__tests__/Hearing/__snapshots__/SectionImage.react-test.js.snap
+++ b/__tests__/Hearing/__snapshots__/SectionImage.react-test.js.snap
@@ -1,20 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SectionImage component should render as expected 1`] = `
-<div
+<figure
   className="section-image"
   key="https://api.hel.fi/kerrokantasi-test/media/images/2017/10/LzqVMrMI.jpeg"
 >
   <img
-    alt="Amazing Title"
+    alt="Mock Von Caption"
     className="img-responsive"
     src="https://api.hel.fi/kerrokantasi-test/media/images/2017/10/LzqVMrMI.jpeg"
-    title="Amazing Title"
   />
-  <div
+  <figcaption
     className="image-caption"
   >
     Mock Von Caption
-  </div>
-</div>
+  </figcaption>
+</figure>
 `;

--- a/assets/sass/kerrokantasi/_hearing-page.scss
+++ b/assets/sass/kerrokantasi/_hearing-page.scss
@@ -149,6 +149,14 @@
   font-size: 1.4rem;
 }
 
+.section-image {
+  margin-bottom: 15px;
+
+  .image-caption {
+    margin-bottom: 0;
+  }
+}
+
 .hearing-contacts {
   border: 1px solid $gray-light;
   padding: 0 $line-height-computed;

--- a/src/components/BaseCommentForm.js
+++ b/src/components/BaseCommentForm.js
@@ -366,7 +366,7 @@ export class BaseCommentForm extends React.Component {
                 (image, key) =>
                   <img
                     style={{ marginRight: 10 }}
-                    alt={image.title}
+                    alt=""
                     src={image.image}
                     width={image.width < 100 ? image.width : 100}
                     height={image.height < 100 ? image.width : 100}

--- a/src/components/Hearing/Comment/index.js
+++ b/src/components/Hearing/Comment/index.js
@@ -474,7 +474,7 @@ class Comment extends React.Component {
                   href={image.url}
                 >
                   <img
-                    alt={image.title}
+                    alt=""
                     src={image.url}
                     width={image.width < 100 ? image.width : 100}
                     height={image.height < 100 ? image.height : 100}

--- a/src/components/Hearing/Section/SectionContainer.js
+++ b/src/components/Hearing/Section/SectionContainer.js
@@ -223,6 +223,7 @@ export class SectionContainerComponent extends React.Component {
                         image={sectionImage}
                         caption={getAttr(sectionImage.caption, language)}
                         title={getAttr(sectionImage.title, language)}
+                        altText={getAttr(sectionImage.alt_text, language)}
                         showLightbox={showLightbox}
                         openLightbox={this.openLightbox}
                         closeLightbox={this.closeLightbox}

--- a/src/components/Hearing/Section/SectionImage.js
+++ b/src/components/Hearing/Section/SectionImage.js
@@ -2,13 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Lightbox from 'react-image-lightbox';
 
-export const SectionImageComponent = ({image, caption, title, showLightbox, openLightbox, closeLightbox}) => {
+export const SectionImageComponent = ({image, altText, caption, title, showLightbox, openLightbox, closeLightbox}) => {
+  const defineImageAlt = () => altText || caption || title || '';
+
   return (
-    <div className="section-image" key={image.url}>
+    <figure className="section-image" key={image.url}>
       <img
         className="img-responsive"
-        alt={title}
-        title={title}
+        alt={defineImageAlt()}
         src={image.url}
         onClick={openLightbox}
         onKeyPress={openLightbox}
@@ -20,8 +21,8 @@ export const SectionImageComponent = ({image, caption, title, showLightbox, open
           onCloseRequest={closeLightbox}
         />
       }
-      <div className="image-caption">{caption}</div>
-    </div>
+      {caption && <figcaption className="image-caption">{caption}</figcaption>}
+    </figure>
   );
 };
 
@@ -29,6 +30,7 @@ SectionImageComponent.propTypes = {
   image: PropTypes.object,
   caption: PropTypes.string,
   title: PropTypes.string,
+  altText: PropTypes.string,
   showLightbox: PropTypes.bool,
   openLightbox: PropTypes.func,
   closeLightbox: PropTypes.func


### PR DESCRIPTION
Add an empty alt tag for images in comments since it's impossible
to give the image an alt tag. This will make the screen readers skip
these images.

Define alt text for main hearing image: If there's no title or caption
provided, use an empty alt tag. If a caption is defined but no title, use
caption. If the title for image is defined, it will be used instead.

Also don't display the image caption element at all if no caption is
provided.

Fixes #707 