### PR TITLE
[WIP] Perform logout by taking user through tunnistamo logout page

### DIFF
--- a/__tests__/login-logout.js
+++ b/__tests__/login-logout.js
@@ -17,7 +17,7 @@ describe('Login/logout', () => {
         username: 'mock.von.user',
         provider: 'helsinki',
       }),
-      "/logout": "OK"
+      "/logout/?next=/": "{\"sso-logout-url\": \"/\"}"
     });
     replace(fetcher);  // Replace the /me endpoint with a mock.
     const store = createTestStore();
@@ -32,7 +32,7 @@ describe('Login/logout', () => {
       // now let's log out...
       return store.dispatch(logout());
     }).then(() => {
-      expect(fetcher.calls["/logout"]).toEqual(1); // The remote call was made
+      expect(fetcher.calls["/logout/?next=/"]).toEqual(1); // The remote call was made
       expect(getUser(store.getState())).toBeNull(); // And the local state was updated
     });
   });

--- a/__tests__/login-logout.js
+++ b/__tests__/login-logout.js
@@ -17,7 +17,7 @@ describe('Login/logout', () => {
         username: 'mock.von.user',
         provider: 'helsinki',
       }),
-      "/logout/?next=/": "{\"sso-logout-url\": \"/\"}"
+      "/logout/": "OK"
     });
     replace(fetcher);  // Replace the /me endpoint with a mock.
     const store = createTestStore();
@@ -32,7 +32,6 @@ describe('Login/logout', () => {
       // now let's log out...
       return store.dispatch(logout());
     }).then(() => {
-      expect(fetcher.calls["/logout/?next=/"]).toEqual(1); // The remote call was made
       expect(getUser(store.getState())).toBeNull(); // And the local state was updated
     });
   });

--- a/config_dev.toml.example
+++ b/config_dev.toml.example
@@ -1,3 +1,5 @@
+######################## Common settings ##############################
+
 # Address and port the server will listen to. The ones below are defaults
 # useful for development. On a more formal occasion you will likely to want
 # change these.
@@ -15,6 +17,11 @@ kerrokantasi_api_jwt_audience="replace-me-with-real-target-app-for-authenticatio
 # Image to use for the hero of the front page
 hero_image_url="http://materialbank.myhelsinki.fi/detail/1192/download/7"
 
+# Tunnistamo (Helsinki SSO) URL to use. Kerrokantasi currently uses some
+# authentication calls that are specific to tunnistamo, although
+# some other systems might be flexible enough to support them as well.
+tunnistamo_url="https://api.hel.fi/sso"
+
 # Our own client identifier in the SSO system, SSO uses this to decide
 # which authentication methods are available and which (API) audiences are allowed
 auth_client_id="replace-me-with-real-auth-id-for-authentication-to-work"
@@ -26,18 +33,18 @@ auth_shared_secret="replace-me-with-real-auth-secret-for-authentication-to-work"
 # Specifies the canonical URL for this service. Kerrokantasi-UI currently
 # uses this for generating the requested callback address from SSO. This
 # will need to match whatever you enter in the browser address bar to reach
-# the UI and the SSO must also be configured to accept this.
-# Default is again for development.
+# the UI, and the SSO must also be configured to accept this.
+# Default is, again, for development.
 public_url="http://localhost:8086"
 
 # ExpressJS uses this secret for purposes. We are not sure if kerrokantasi-ui
-# actually uses it for something. It is still required
+# actually uses that functionality. It is still required.
 expressjs_session_secret="dev-secret-do-not-use-in-production"
 
+#################### City specific configuration ######################
 
-# City specific configuration
 # For whitelabel styles use "whitelabel".
-# For city assets installed to node_modules us the name of the package
+# For city assets installed to node_modules use the name of the package
 # for instance "kerrokantasi-ui-turku".
 # Default: "cities/helsinki"
 city_config="cities/helsinki"

--- a/server/auth.js
+++ b/server/auth.js
@@ -43,6 +43,10 @@ export function getPassport(settings) {
       clientID: settings.auth_client_id,
       clientSecret: settings.auth_shared_secret,
       callbackURL: settings.public_url + '/login/helsinki/return',
+      authorizationURL: 'https://api.hel.fi/sso-test/oauth2/authorize/',
+      tokenURL: 'https://api.hel.fi/sso-test/oauth2/token/',
+      userProfileURL: 'https://api.hel.fi/sso-test/user/',
+      appTokenURL: 'https://api.hel.fi/sso-test/jwt-token/'
     },
     (accessToken, refreshToken, profile, done) => {
       debug('access token:', accessToken);
@@ -99,7 +103,7 @@ export function addAuth(server, passport) {
   server.post('/logout', (req, res) => {
     req.logout();
     const redirectUrl = req.query.next || '/';
-    res.redirect(`https://api.hel.fi/sso/logout/?next=${redirectUrl}`);
+    res.json({"sso-logout-url": `https://api.hel.fi/sso-test/logout/?next=${redirectUrl}` });
   });
   server.get('/me', (req, res) => {
     res.json(req.user || {});

--- a/server/auth.js
+++ b/server/auth.js
@@ -102,8 +102,7 @@ export function addAuth(server, passport) {
   });
   server.post('/logout', (req, res) => {
     req.logout();
-    const redirectUrl = req.query.next || '/';
-    res.json({"sso-logout-url": `https://api.hel.fi/sso-test/logout/?next=${redirectUrl}` });
+    res.redirect(`https://api.hel.fi/sso-test/logout/`);
   });
   server.get('/me', (req, res) => {
     res.json(req.user || {});

--- a/server/auth.js
+++ b/server/auth.js
@@ -43,10 +43,10 @@ export function getPassport(settings) {
       clientID: settings.auth_client_id,
       clientSecret: settings.auth_shared_secret,
       callbackURL: settings.public_url + '/login/helsinki/return',
-      authorizationURL: 'https://api.hel.fi/sso-test/oauth2/authorize/',
-      tokenURL: 'https://api.hel.fi/sso-test/oauth2/token/',
-      userProfileURL: 'https://api.hel.fi/sso-test/user/',
-      appTokenURL: 'https://api.hel.fi/sso-test/jwt-token/'
+      authorizationURL: settings.tunnistamo_url + '/oauth2/authorize/',
+      tokenURL: settings.tunnistamo_url + '/oauth2/token/',
+      userProfileURL: settings.tunnistamo_url + '/user/',
+      appTokenURL: settings.tunnistamo_url + '/jwt-token/'
     },
     (accessToken, refreshToken, profile, done) => {
       debug('access token:', accessToken);
@@ -88,7 +88,7 @@ function successfulLoginHandler(req, res) {
   res.send('<html><body>Login successful.<script>' + js + '</script>');
 }
 
-export function addAuth(server, passport) {
+export function addAuth(server, passport, settings) {
   server.use(passport.initialize());
   server.use(passport.session());
   server.get('/login/helsinki', passport.authenticate('helsinki'));
@@ -102,7 +102,7 @@ export function addAuth(server, passport) {
   });
   server.post('/logout', (req, res) => {
     req.logout();
-    res.redirect(`https://api.hel.fi/sso-test/logout/`);
+    res.redirect(`${settings.tunnistamo_url}/logout/`);
   });
   server.get('/me', (req, res) => {
     res.json(req.user || {});

--- a/server/getSettings.js
+++ b/server/getSettings.js
@@ -12,6 +12,8 @@ const defaults = {
   public_url: 'http://localhost:8080',
   // Image used as background for the Hero
   hero_image_url: 'https://source.unsplash.com/1600x900/?squirrel',
+  // Base URL for the Helsinki SSO instance
+  tunnistamo_url: 'https://api.hel.fi/sso',
   // Client Identifier in the Helsinki SSO system
   auth_client_id: null,
   // Shared secret in the Helsinki SSO system
@@ -32,6 +34,7 @@ const optionalKeys = [
   "kerrokantasi_api_base",
   "public_url",
   "hero_image_url",
+  "tunnistamo_url",
   "ui_config",
   "dev",
   "cold",

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -57,18 +57,20 @@ export function login() {
 export function logout() {
   return (dispatch) => {
     return new Promise((resolve) => {
+      dispatch(createAction('clearUserData')());
+      // the store may contain hearings not fit for nonauthorized eyes!
+      dispatch(createAction('clearNonPublicHearings')());
       // UI server controls the logout process as well
       const logOutPopup = window.open(
         '/logout',
         'kkLogoutWindow',
         'location,scrollbars=on,width=720,height=600'
       );
-      logOutPopup.onload(
-        setTimeout(logoutPopup => logOutPopup.close(), 5000)
-      );
-      dispatch(createAction('clearUserData')());
-      // the store may contain hearings not fit for nonauthorized eyes!
-      dispatch(createAction('clearNonPublicHearings')());
+      setTimeout((logoutPopup) => {
+        logOutPopup.close();
+        // Hopefully the logout has completed by now.
+        resolve();
+      }, 5000);
     });
   };
 }

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -58,8 +58,9 @@ export function logout() {
   return (dispatch) => {
     // This returns a promise for symmetry with login; it's actually a synchronous action.
     return new Promise((resolve) => {
+      var next_url = window.location.origin.length == 0 ? window.location.origin : '';
       // origin is without the trailing slash
-      fetch(`/logout/?next=${location.origin}/`, {method: 'POST', credentials: 'same-origin'}).then(
+      fetch(`/logout/?next=${next_url}/`, {method: 'POST', credentials: 'same-origin'}).then(
         (result) => resolve(result.json())
       );
       dispatch(createAction('clearUserData')());

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -56,12 +56,15 @@ export function login() {
 
 export function logout() {
   return (dispatch) => {
-    // This returns a promise for symmetry with login; it's actually a synchronous action.
     return new Promise((resolve) => {
-      var next_url = window.location.origin.length == 0 ? window.location.origin : '';
-      // origin is without the trailing slash
-      fetch(`/logout/?next=${next_url}/`, {method: 'POST', credentials: 'same-origin'}).then(
-        (result) => resolve(result.json())
+      // UI server controls the logout process as well
+      const logOutPopup = window.open(
+        '/logout',
+        'kkLogoutWindow',
+        'location,scrollbars=on,width=720,height=600'
+      );
+      logOutPopup.onload(
+        setTimeout(logoutPopup => logOutPopup.close(), 5000)
       );
       dispatch(createAction('clearUserData')());
       // the store may contain hearings not fit for nonauthorized eyes!

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -58,11 +58,13 @@ export function logout() {
   return (dispatch) => {
     // This returns a promise for symmetry with login; it's actually a synchronous action.
     return new Promise((resolve) => {
-      fetch('/logout', {method: 'POST', credentials: 'same-origin'});  // Fire-and-forget
+      // origin is without the trailing slash
+      fetch(`/logout/?next=${location.origin}/`, {method: 'POST', credentials: 'same-origin'}).then(
+        (result) => resolve(result.json())
+      );
       dispatch(createAction('clearUserData')());
       // the store may contain hearings not fit for nonauthorized eyes!
       dispatch(createAction('clearNonPublicHearings')());
-      resolve();
     });
   };
 }

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -49,10 +49,7 @@ class Header extends React.Component {
       case 'logout':
         // TODO: Actual logout flow
         logout();
-        this.props.dispatch(logout())
-        .then((logout_response) => {
-          window.location = logout_response['sso-logout-url'];
-        });
+        this.props.dispatch(logout());
         break;
       default:
       // Not sure what to do here

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -48,7 +48,11 @@ class Header extends React.Component {
         break;
       case 'logout':
         // TODO: Actual logout flow
-        this.props.dispatch(logout());
+        logout();
+        this.props.dispatch(logout())
+        .then((logout_response) => {
+          window.location = logout_response['sso-logout-url'];
+        });
         break;
       default:
       // Not sure what to do here

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -48,7 +48,6 @@ class Header extends React.Component {
         break;
       case 'logout':
         // TODO: Actual logout flow
-        logout();
         this.props.dispatch(logout());
         break;
       default:


### PR DESCRIPTION
Makes logout actually do a logout at tunnistamo. This would not previously work, as tunnistamo does not allow fetch access to the logout endpoint.

Note that this is still hardcoded for tunnnistamo-test.