### PR TITLE
Fix main navigation issues

### DIFF
--- a/__tests__/Hearing/__snapshots__/HearingContainer.react-test.js.snap
+++ b/__tests__/Hearing/__snapshots__/HearingContainer.react-test.js.snap
@@ -329,6 +329,8 @@ exports[`HearingContainer component should render as expected 1`] = `
             "fullscreenHeaderLogoAlt": "Kerrokantasi logo",
             "furtherInformation": "Lisätietoja",
             "headerLogoAlt": "Kerrokantasi logo",
+            "headerPagesNavLabel": "Sivuvalikko",
+            "headerUserNavLabel": "Käyttäjävalikko",
             "headerWriteCommentLink": "Kirjoita kommentti",
             "hearing": "Kuuleminen",
             "hearingAbstract": "Lyhyt johdanto",

--- a/__tests__/Hearings/__snapshots__/HearingList.react-test.js.snap
+++ b/__tests__/Hearings/__snapshots__/HearingList.react-test.js.snap
@@ -122,6 +122,8 @@ exports[`HearingsList component should render as expected 1`] = `
                   "fullscreenHeaderLogoAlt": "Kerrokantasi logo",
                   "furtherInformation": "Lisätietoja",
                   "headerLogoAlt": "Kerrokantasi logo",
+                  "headerPagesNavLabel": "Sivuvalikko",
+                  "headerUserNavLabel": "Käyttäjävalikko",
                   "headerWriteCommentLink": "Kirjoita kommentti",
                   "hearing": "Kuuleminen",
                   "hearingAbstract": "Lyhyt johdanto",

--- a/__tests__/Hearings/__snapshots__/Hearings.react-test.js.snap
+++ b/__tests__/Hearings/__snapshots__/Hearings.react-test.js.snap
@@ -181,6 +181,8 @@ exports[`Hearings component should render as expected 1`] = `
           "fullscreenHeaderLogoAlt": "Kerrokantasi logo",
           "furtherInformation": "Lisätietoja",
           "headerLogoAlt": "Kerrokantasi logo",
+          "headerPagesNavLabel": "Sivuvalikko",
+          "headerUserNavLabel": "Käyttäjävalikko",
           "headerWriteCommentLink": "Kirjoita kommentti",
           "hearing": "Kuuleminen",
           "hearingAbstract": "Lyhyt johdanto",

--- a/__tests__/Home/__snapshots__/FullWidthHearing.react-test.js.snap
+++ b/__tests__/Home/__snapshots__/FullWidthHearing.react-test.js.snap
@@ -106,6 +106,8 @@ exports[`FullWidthHearing component should render as expected 1`] = `
         "fullscreenHeaderLogoAlt": "Kerrokantasi logo",
         "furtherInformation": "Lisätietoja",
         "headerLogoAlt": "Kerrokantasi logo",
+        "headerPagesNavLabel": "Sivuvalikko",
+        "headerUserNavLabel": "Käyttäjävalikko",
         "headerWriteCommentLink": "Kirjoita kommentti",
         "hearing": "Kuuleminen",
         "hearingAbstract": "Lyhyt johdanto",

--- a/__tests__/__snapshots__/SortableCommentList.react-test.js.snap
+++ b/__tests__/__snapshots__/SortableCommentList.react-test.js.snap
@@ -290,6 +290,8 @@ exports[`SortableCommentList component should render as expected 1`] = `
                 "fullscreenHeaderLogoAlt": "Kerrokantasi logo",
                 "furtherInformation": "Lisätietoja",
                 "headerLogoAlt": "Kerrokantasi logo",
+                "headerPagesNavLabel": "Sivuvalikko",
+                "headerUserNavLabel": "Käyttäjävalikko",
                 "headerWriteCommentLink": "Kirjoita kommentti",
                 "hearing": "Kuuleminen",
                 "hearingAbstract": "Lyhyt johdanto",

--- a/assets/sass/kerrokantasi/variables.scss
+++ b/assets/sass/kerrokantasi/variables.scss
@@ -73,6 +73,8 @@ $navbar-default-link-color:       $black !default;
 $navbar-default-link-hover-color: $black !default;
 $navbar-default-bg:               $white !default;
 $navbar-default-border:           transparent !default;
+$navbar-default-link-active-color:$navbar-default-link-hover-color !default;
+$navbar-default-link-active-bg:   transparent !default;
 
 $label-default-bg:  $gray-400 !default;
 $label-primary-bg:  $theme-primary-light !default;

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-multi-comp */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Navbar, Nav, NavItem, Button, DropdownButton, MenuItem } from 'react-bootstrap';
+import { Navbar, Button, DropdownButton, MenuItem } from 'react-bootstrap';
 import Icon from '../../utils/Icon';
 import LanguageSwitcher from './LanguageSwitcher';
 import { FormattedMessage } from 'react-intl';
@@ -96,17 +96,27 @@ class Header extends React.Component {
   getNavItem(id, url) {
     const {history, language} = this.props;
     const active = history && history.location.pathname === url;
-    const navItem = (
-      <NavItem key={id} eventKey={id} href="#" active={active}>
+    const navLink = (
+      <a href="#">
         <FormattedMessage id={id + 'HeaderText'} />
-      </NavItem>
+      </a>
     );
     if (url) {
       // Can't use custom link component here because it will break the navigation
       // so LinkContainer must contain same logic
-      return <LinkContainer to={url + '?lang=' + language}>{navItem}</LinkContainer>;
+      return (
+        <li className={`nav-item ${active ? 'active' : ''}`}>
+          <LinkContainer to={url + '?lang=' + language} className="nav-link">
+            {navLink}
+          </LinkContainer>
+        </li>
+      );
     }
-    return navItem;
+    return (
+      <li className={`nav-item ${active && 'active'}`}>
+        {navLink}
+      </li>
+    );
   }
 
   render() {
@@ -118,43 +128,52 @@ class Header extends React.Component {
     const userItems = this.getUserItems();
     return (
       <div>
-        <Navbar fluid staticTop defaultExpanded className="navbar-kerrokantasi">
-          <Navbar.Header>
-            <Navbar.Brand>
-              <Link to={{path: "/"}}>
-                <FormattedMessage id="headerLogoAlt">
-                  {altText => <img
-                    src={language === 'sv' ? logoSwedishBlack : logoBlack}
-                    className="navbar-logo"
-                    alt={altText}
-                  />}
-                </FormattedMessage>
-              </Link>
-            </Navbar.Brand>
-          </Navbar.Header>
+        <FormattedMessage id="headerUserNavLabel">
+          {headerUserNavLabel => (
+            <Navbar fluid staticTop defaultExpanded className="navbar-kerrokantasi" aria-label={headerUserNavLabel}>
+              <Navbar.Header>
+                <Navbar.Brand>
+                  <Link to={{ path: "/" }}>
+                    <FormattedMessage id="headerLogoAlt">
+                      {altText => <img
+                        src={language === 'sv' ? logoSwedishBlack : logoBlack}
+                        className="navbar-logo"
+                        alt={altText}
+                      />}
+                    </FormattedMessage>
+                  </Link>
+                </Navbar.Brand>
+              </Navbar.Header>
 
-          <div onSelect={onSelect} className="nav-user-menu navbar-right">
-            <LanguageSwitcher currentLanguage={this.props.language} />
-            {userItems}
-          </div>
-        </Navbar>
-        <Navbar default fluid collapseOnSelect className="navbar-primary">
-          <Navbar.Header>
-            <Navbar.Brand>
-              <Link to={{path: "/"}}>
-                Kerrokantasi
-              </Link>
-            </Navbar.Brand>
-            <Navbar.Toggle />
-          </Navbar.Header>
-          <Navbar.Collapse>
-            <Nav>
-              {this.getNavItem('hearings', '/hearings/list')}
-              {this.getNavItem('hearingMap', '/hearings/map')}
-              {this.getNavItem('info', '/info')}
-            </Nav>
-          </Navbar.Collapse>
-        </Navbar>
+              <div onSelect={onSelect} className="nav-user-menu navbar-right">
+                <LanguageSwitcher currentLanguage={this.props.language} />
+                {userItems}
+              </div>
+            </Navbar>
+          )}
+        </FormattedMessage>
+
+        <FormattedMessage id="headerPagesNavLabel">
+          {headerPagesNavLabel => (
+            <Navbar default fluid collapseOnSelect className="navbar-primary" aria-label={headerPagesNavLabel}>
+              <Navbar.Header>
+                <Navbar.Brand>
+                  <Link to={{path: "/"}}>
+                    Kerrokantasi
+                  </Link>
+                </Navbar.Brand>
+                <Navbar.Toggle />
+              </Navbar.Header>
+              <Navbar.Collapse>
+                <ul className="nav navbar-nav">
+                  {this.getNavItem('hearings', '/hearings/list')}
+                  {this.getNavItem('hearingMap', '/hearings/map')}
+                  {this.getNavItem('info', '/info')}
+                </ul>
+              </Navbar.Collapse>
+            </Navbar>
+          )}
+        </FormattedMessage>
       </div>
     );
   }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -190,5 +190,7 @@
   "voteButtonLikes": "Likes",
   "voteButtonText": "Like this comment",
   "accessibilityLink": "Accessibility Statement",
-  "accessibilityPage": "Accessibility Statement"
+  "accessibilityPage": "Accessibility Statement",
+  "headerUserNavLabel": "User menu",
+  "headerPagesNavLabel": "Page menu"
 }

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -272,5 +272,7 @@
   "voteButtonLikes": "Tykkäystä",
   "voteButtonText": "Tykkää tästä kommentista",
   "accessibilityLink": "Saavutettavuusseloste",
-  "accessibilityPage": "Saavutettavuusseloste"
+  "accessibilityPage": "Saavutettavuusseloste",
+  "headerUserNavLabel": "Käyttäjävalikko",
+  "headerPagesNavLabel": "Sivuvalikko"
 }

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -175,5 +175,7 @@
   "voteButtonLikes": "Gillar",
   "voteButtonText": "Gillar den här kommentaren",
   "accessibilityLink": "Tillgänglighetsutlåtande",
-  "accessibilityPage": "Tillgänglighetsutlåtande"
+  "accessibilityPage": "Tillgänglighetsutlåtande",
+  "headerUserNavLabel": "Användarmeny",
+  "headerPagesNavLabel": "Sidmenyn"
 }


### PR DESCRIPTION
There are two `<nav>` elements so both need to have a label that defines them. Add aria-labels to both of these elements.

Page nav links did not work correctly and the bootstrap element added `role="presentation"` to the `<li>` elements which causes issues with accessibility. Remove the bootstrap react element and use handwritten version instead.