### PR TITLE
Update share metadata title to hearing title

### DIFF
--- a/server/Html.js
+++ b/server/Html.js
@@ -28,7 +28,7 @@ export default class Html extends React.Component {
           <meta charSet="utf-8"/>
           <meta httpEquiv="X-UA-Compatible" content="IE=edge"/>
           <meta content="width=device-width, initial-scale=1" name="viewport"/>
-          {head ? head.title.toComponent() : <title>Kerrokantasi</title>}
+          {hearingData && hearingData.title && <title>hearingData.title.fi</title>}
           {head ? head.meta.toComponent() : null}
           {head ? head.link.toComponent() : null}
           {hearingData && hearingData.main_image && <meta property="og:image" content={hearingData.main_image.url} />}


### PR DESCRIPTION
Currently, the metadata title when sharing a hearing is fixed to "Kerrokantasi". This doesn't really tell the user who sees the thumbnail what the image and link is about.

I suggest displaying the title of the hearing instead. That way, when shared on facebook and twitter, users see the hearing title.

![image](https://user-images.githubusercontent.com/9367712/65607535-65b5d200-dfb5-11e9-820e-9f460e481a6c.png)
