### PR TITLE
Manage focused element after clicking labels

### DIFF
--- a/__tests__/Hearings/__snapshots__/HearingList.react-test.js.snap
+++ b/__tests__/Hearings/__snapshots__/HearingList.react-test.js.snap
@@ -18,7 +18,7 @@ exports[`HearingsList component should render as expected 1`] = `
           md={10}
           mdPush={1}
         >
-          <HearingsSearch
+          <Connect(HearingsSearch)
             intl={
               Object {
                 "defaultFormats": Object {},

--- a/__tests__/__snapshots__/LabelList.react-test.js.snap
+++ b/__tests__/__snapshots__/LabelList.react-test.js.snap
@@ -18,6 +18,9 @@ exports[`LabelList can handle list of label objects 1`] = `
       Object {
         "path": "/hearings/list",
         "search": "?label=1",
+        "state": Object {
+          "filteredByLabelLink": true,
+        },
       }
     }
   >
@@ -35,6 +38,9 @@ exports[`LabelList can handle list of label objects 1`] = `
       Object {
         "path": "/hearings/list",
         "search": "?label=2",
+        "state": Object {
+          "filteredByLabelLink": true,
+        },
       }
     }
   >

--- a/src/components/HearingsSearch.js
+++ b/src/components/HearingsSearch.js
@@ -1,13 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
 import {FormGroup, FormControl, ControlLabel, Button} from 'react-bootstrap';
 import {FormattedMessage, intlShape} from 'react-intl';
 import Select from 'react-select';
-import isEmpty from 'lodash/isEmpty';
+import {get, isEmpty} from 'lodash';
 import getAttr from '../utils/getAttr';
 import {labelShape} from '../types';
 
 class HearingsSearch extends React.Component {
+  constructor(props) {
+    super(props);
+    this.hearingFilterSearch = React.createRef();
+  }
+
+  componentDidUpdate() {
+    if (this.props.routerLocationState.filteredByLabelLink) {
+      this.hearingFilterSearch.current.focus();
+    }
+  }
+
   render() {
     const {
       handleSearch,
@@ -51,6 +63,7 @@ class HearingsSearch extends React.Component {
                   onChange={(value) => handleSelectLabels(value)}
                   placeholder={intl.formatMessage({id: 'searchPlaceholder'})}
                   id="formControlsSearchSelect"
+                  ref={this.hearingFilterSearch}
                 />
               )}
             </FormGroup>
@@ -67,6 +80,10 @@ class HearingsSearch extends React.Component {
   }
 }
 
+const mapStateToProps = state => ({
+  routerLocationState: get(state, 'router.location.state', {}),
+});
+
 HearingsSearch.propTypes = {
   handleSearch: PropTypes.func,
   handleSelectLabels: PropTypes.func,
@@ -74,7 +91,8 @@ HearingsSearch.propTypes = {
   language: PropTypes.string,
   searchPhrase: PropTypes.string,
   selectedLabels: PropTypes.arrayOf(PropTypes.string),
-  intl: intlShape.isRequired
+  intl: intlShape.isRequired,
+  routerLocationState: PropTypes.object,
 };
 
-export default HearingsSearch;
+export default connect(mapStateToProps)(HearingsSearch);

--- a/src/components/LabelList.js
+++ b/src/components/LabelList.js
@@ -22,7 +22,14 @@ export class Labels extends React.Component {
     */
 
     const labelToHTML = (label) => (
-      <Link to={{path: '/hearings/list', search: `?label=${label.id}`}} key={label.id || label}>
+      <Link
+        to={{
+          path: '/hearings/list',
+          search: `?label=${label.id}`,
+          state: { filteredByLabelLink: true }
+        }}
+        key={label.id || label}
+      >
         <Label bsStyle="info">{getAttr(label.label, language)}</Label>{' '}
       </Link>
     );


### PR DESCRIPTION
When the user clicks a label to filter hearings
with that specific tag/label, change focus to the
select element in the hearing list search.

This is done due that with screen readers the user
loses context when they click one of the labels.

Now the focus will go on the search dropdown element
where these filters are applied.

![image](https://user-images.githubusercontent.com/7901266/65958310-c0d54200-e457-11e9-8b21-c8becfa65055.png)

![image](https://user-images.githubusercontent.com/7901266/65958341-d64a6c00-e457-11e9-99e3-7a21a66cbf5e.png)
