### PR TITLE
Fix flex bug with safari on hearing page

### DIFF
--- a/assets/sass/kerrokantasi/_hearing-subsections.scss
+++ b/assets/sass/kerrokantasi/_hearing-subsections.scss
@@ -39,7 +39,8 @@
 
   &-content {
     padding: $grid-gutter-width / 2;
-    flex: 1 1 100%;
+    flex-basis: 0%;
+    flex: 1 1 auto;
     display: flex;
     flex-flow: column wrap;
     justify-content: space-between;


### PR DESCRIPTION
The subhearing box got really tall in Safari. This will fix it

<img width="1783" alt="safari-flex-bug" src="https://user-images.githubusercontent.com/7901266/66125802-9c609d80-e5f0-11e9-98fb-813d1165bb9f.png">
