### PR TITLE
Fix hearing count on hearings list

### DIFF
--- a/__tests__/Hearings/__snapshots__/HearingList.react-test.js.snap
+++ b/__tests__/Hearings/__snapshots__/HearingList.react-test.js.snap
@@ -393,33 +393,7 @@ exports[`HearingsList component should render as expected 1`] = `
             >
               <h3
                 className="hearing-list__hearing-list-title"
-              >
-                1
-                <FormattedPlural
-                  one={
-                    <FormattedMessage
-                      id="totalNumHearing"
-                      values={
-                        Object {
-                          "n": 1,
-                        }
-                      }
-                    />
-                  }
-                  other={
-                    <FormattedMessage
-                      id="totalNumHearings"
-                      values={
-                        Object {
-                          "n": 1,
-                        }
-                      }
-                    />
-                  }
-                  style="cardinal"
-                  value={1}
-                />
-              </h3>
+              />
               <HearingListFilters
                 formatMessage={[Function]}
               />

--- a/src/components/HearingList.js
+++ b/src/components/HearingList.js
@@ -213,6 +213,7 @@ export const HearingList = ({
   handleSelectLabels,
   handleSort,
   hearings,
+  hearingCount,
   intl: {formatMessage},
   isLoading,
   isMobile,
@@ -289,12 +290,16 @@ export const HearingList = ({
                 <div>
                   <div className="hearing-list__result-controls">
                     <h3 className="hearing-list__hearing-list-title">
-                      {hearings.length}
-                      <FormattedPlural
-                        value={hearings.length}
-                        one={<FormattedMessage id="totalNumHearing" values={{ n: hearings.length }} />}
-                        other={<FormattedMessage id="totalNumHearings" values={{ n: hearings.length }} />}
-                      />
+                      {hearingCount && (
+                        <span>
+                          {hearingCount}
+                          <FormattedPlural
+                            value={hearingCount}
+                            one={<FormattedMessage id="totalNumHearing" values={{ n: hearingCount }} />}
+                            other={<FormattedMessage id="totalNumHearings" values={{ n: hearingCount }} />}
+                          />
+                        </span>
+                      )}
                     </h3>
                     <HearingListFilters handleSort={handleSort} formatMessage={formatMessage} />
                   </div>
@@ -324,6 +329,7 @@ HearingList.propTypes = {
   handleSelectLabels: PropTypes.func,
   handleSort: PropTypes.func,
   hearings: PropTypes.array,
+  hearingCount: PropTypes.number,
   intl: intlShape.isRequired,
   isLoading: PropTypes.bool,
   isMobile: PropTypes.bool,

--- a/src/views/Hearings/index.js
+++ b/src/views/Hearings/index.js
@@ -129,6 +129,12 @@ export class Hearings extends React.Component {
     return get(hearingLists, [hearingListKey, 'data'], null);
   }
 
+  getHearingsCount() {
+    const { hearingLists } = this.props;
+    const list = this.getHearingListName();
+    return hearingLists[list].count;
+  }
+
   getHearingListName() {
     const { user } = this.props;
     const { adminFilter } = this.state;
@@ -262,6 +268,7 @@ export class Hearings extends React.Component {
     const searchTitle = parseQuery(location.search).search;
     const { showOnlyOpen } = this.state;
     const hearings = this.getHearings();
+    const hearingCount = this.getHearingsCount();
 
     const adminFilterSelector = isAdmin(user.data) ? (
       <AdminFilterSelector
@@ -294,6 +301,7 @@ export class Hearings extends React.Component {
         </section>
         {!isEmpty(labels) ? <WrappedHearingList
           hearings={hearings}
+          hearingCount={hearingCount}
           selectedLabels={selectedLabels ? [].concat(selectedLabels) : []}
           searchPhrase={searchTitle}
           isLoading={this.getIsLoading()}


### PR DESCRIPTION
Hearing counter displayed only the first visible hearings, so if there was more than 10 hearings it didn't display the entire amount of the hearings.