### PR TITLE
Add possibility to hide social media sharing via config variable

### DIFF
--- a/__tests__/Hearing/__snapshots__/Header.react-test.js.snap
+++ b/__tests__/Hearing/__snapshots__/Header.react-test.js.snap
@@ -28,13 +28,6 @@ exports[`Header component should render as expected 1`] = `
               Ideoi Isosaaren tulevaisuutta
             </h1>
           </Col>
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={3}
-          >
-            <SocialBar />
-          </Col>
         </Row>
         <Row
           bsClass="row"

--- a/config_dev.toml.example
+++ b/config_dev.toml.example
@@ -45,3 +45,7 @@ city_config="cities/helsinki"
 # Should display accessibility page link in the footer and accessibility page content
 # Default: false
 # show_accessibility_info=true
+
+# Should display social media share buttons on a hearing header
+# Default: true
+# show_social_media_sharing=false

--- a/server/Html.js
+++ b/server/Html.js
@@ -12,6 +12,7 @@ export default class Html extends React.Component {
       heroImageURL,
       initialState,
       showAccessibilityInfo,
+      showSocialMediaSharing,
       uiConfig,
     } = this.props;
     const initialStateHtml = `
@@ -20,6 +21,7 @@ export default class Html extends React.Component {
     window.HERO_IMAGE_URL = ${JSON.stringify(heroImageURL)};
     window.UI_CONFIG = ${JSON.stringify(uiConfig)};
     window.SHOW_ACCESSIBILITY_INFO = ${JSON.stringify(showAccessibilityInfo)};
+    window.SHOW_SOCIAL_MEDIA_SHARING = ${JSON.stringify(showSocialMediaSharing)};
     `;
 
     return (
@@ -54,4 +56,5 @@ Html.propTypes = {
   initialState: PropTypes.object,
   hearingData: PropTypes.object,
   showAccessibilityInfo: PropTypes.bool,
+  showSocialMediaSharing: PropTypes.bool,
 };

--- a/server/getSettings.js
+++ b/server/getSettings.js
@@ -26,6 +26,8 @@ const defaults = {
   cold: false,
   // Should display accessibility info
   show_accessibility_info: false,
+  // Should display social media sharing buttons
+  show_social_media_sharing: true,
 };
 
 const optionalKeys = [
@@ -39,6 +41,7 @@ const optionalKeys = [
   "cold",
   "city_config",
   "show_accessibility_info",
+  "show_social_media_sharing",
 ];
 
 const mandatoryKeys = [

--- a/server/render-middleware.js
+++ b/server/render-middleware.js
@@ -38,6 +38,7 @@ function renderHTMLSkeleton(req, res, settings) {
         uiConfig={settings.ui_config}
         hearingData={hearingData}
         showAccessibilityInfo={settings.show_accessibility_info}
+        showSocialMediaSharing={settings.show_social_media_sharing}
       />
     );
     res.status(200).send(html);

--- a/src/components/Hearing/Header.js
+++ b/src/components/Hearing/Header.js
@@ -16,6 +16,7 @@ import SectionClosureInfo from '../../components/Hearing/Section/SectionClosureI
 import SocialBar from '../../components/SocialBar';
 import getAttr from '../../utils/getAttr';
 import Link from '../LinkWithLang';
+import config from '../../config';
 import { isPublic, getHearingURL, hasCommentableSections } from "../../utils/hearing";
 import { SectionTypes, isMainSection, isSectionCommentable } from '../../utils/section';
 import { stringifyQuery } from '../../utils/urlQuery';
@@ -217,7 +218,7 @@ export class HeaderComponent extends React.Component {
                     {getAttr(hearing.title, activeLanguage)}
                   </h1>
                 </Col>
-                {isMainSection(section) && (
+                {(isMainSection(section) && config.showSocialMediaSharing) && (
                   <Col md={3}>
                     <SocialBar />
                   </Col>

--- a/src/config.js
+++ b/src/config.js
@@ -9,6 +9,7 @@ const config = {
   heroImageURL: (typeof window !== 'undefined' ? window.HERO_IMAGE_URL : null)
     || 'http://materialbank.myhelsinki.fi/detail/1192/download/7',
   showAccessibilityInfo: typeof window !== 'undefined' ? window.SHOW_ACCESSIBILITY_INFO : false,
+  showSocialMediaSharing: typeof window !== 'undefined' ? window.SHOW_SOCIAL_MEDIA_SHARING : true,
 };
 
 export default config;


### PR DESCRIPTION
Not every city needs the social media sharing so make it possible to hide them from hearing headers.

By default the social media sharing buttons are shown.