### PR TITLE
Switch map element DOM order in hearing section

### DIFF
--- a/__tests__/Hearing/__snapshots__/SectionContainer.react-test.js.snap
+++ b/__tests__/Hearing/__snapshots__/SectionContainer.react-test.js.snap
@@ -17,9 +17,7 @@ exports[`SectionContainer component should render as expected 1`] = `
         <Col
           bsClass="col"
           componentClass="div"
-          lgPull={null}
           md={8}
-          mdPull={null}
           mdPush={2}
         >
           <section

--- a/src/components/Header/LanguageSwitcher.js
+++ b/src/components/Header/LanguageSwitcher.js
@@ -20,7 +20,6 @@ const LanguageSwitcher = ({currentLanguage, location, history}, {intl: {formatMe
     pullRight
     className="language-switcher"
     id="language"
-    eventKey="language"
     title={<span><Icon name="globe" className="user-nav-icon" aria-hidden="true"/>{currentLanguage} </span>}
     aria-label={formatMessage({id: 'languageSwitchLabel'})}
   >

--- a/src/components/Hearing/Section/SectionContainer.js
+++ b/src/components/Hearing/Section/SectionContainer.js
@@ -54,6 +54,7 @@ export class SectionContainerComponent extends React.Component {
     commentToDelete: {},
     showLightbox: false,
     mapContainer: null,
+    mapContainerMobile: null,
     mainHearingDetailsOpen: false,
     mainHearingProjectOpen: false,
     mainHearingContactsOpen: false,
@@ -86,6 +87,9 @@ export class SectionContainerComponent extends React.Component {
   // Save reference in state.
   handleSetMapContainer = (mapContainer) => {
     this.setState({ mapContainer });
+  }
+  handleSetMapContainerMobile = (mapContainerMobile) => {
+    this.setState({ mapContainerMobile });
   }
 
   /**
@@ -493,13 +497,13 @@ export class SectionContainerComponent extends React.Component {
     return (
       <React.Fragment>
         {hearing.geojson && (
-          <Col md={4} lg={3} mdPush={8} lgPush={9}>
-            <div className="hearing-map-container" ref={this.handleSetMapContainer}>
-              <HearingMap hearing={hearing} mapContainer={this.state.mapContainer} />
+          <Col xs={12} className="hidden-md hidden-lg">
+            <div className="hearing-map-container" ref={this.handleSetMapContainerMobile}>
+              <HearingMap hearing={hearing} mapContainer={this.state.mapContainerMobile} />
             </div>
           </Col>
         )}
-        <Col md={8} mdPull={hearing.geojson && 4} lgPull={hearing.geojson && 3} mdPush={!hearing.geojson ? 2 : 0}>
+        <Col md={8} mdPush={!hearing.geojson ? 2 : 0}>
           {this.renderMainDetails(hearing, section, language)}
 
           {this.renderProjectPhaseSection(hearing, language)}
@@ -535,6 +539,13 @@ export class SectionContainerComponent extends React.Component {
 
           {this.renderCommentsSection()}
         </Col>
+        {hearing.geojson && (
+          <Col md={4} lg={3} lgPush={1} className="hidden-xs visible-sm visible-md visible-lg">
+            <div className="hearing-map-container" ref={this.handleSetMapContainer}>
+              <HearingMap hearing={hearing} mapContainer={this.state.mapContainer} />
+            </div>
+          </Col>
+        )}
       </React.Fragment>
     );
   }


### PR DESCRIPTION
The previous issue was that the content did not occure in an intuitive order for desktop users. Since the map was present in the DOM order before other content and it was swithed on the right side of the content with CSS, the reading order changed from right to left. This is bad for the usability.

The fix was to duplicate the map component for mobile and desktop users. For desktop the map element is in the DOM after the content that's on the left and visually it didn't change at all. For mobile users there's the duplicate which will be visible before the main content.