### PR TITLE
Display small icon after external link

### DIFF
--- a/assets/sass/kerrokantasi/_common.scss
+++ b/assets/sass/kerrokantasi/_common.scss
@@ -92,6 +92,13 @@ textarea {
   max-width: 100%;
 }
 
+// Adds icon to show user that the link is opening to new tab/window
+a[target=_blank]::after {
+  content: '\f08e';
+  font-family: FontAwesome;
+  padding-left: 5px;
+}
+
 a.list-group-item {
   &:hover, &:focus {
     > .badge {


### PR DESCRIPTION
Turku wanted to have quick way to indicate external links with small
icons. After conversations we decided to include this to global styles.

In this case external links are defined as link that opens to new
target. This way the change was small, and no need to create that to the
editors.