### PR TITLE
Comment vote fix

### DIFF
--- a/src/components/Hearing/Section/SectionContainer.js
+++ b/src/components/Hearing/Section/SectionContainer.js
@@ -105,7 +105,7 @@ export class SectionContainerComponent extends React.Component {
     const hearingSlug = match.params.hearingSlug;
     const {authCode} = parseQuery(location.search);
     const commentData = Object.assign({authCode}, sectionCommentData);
-    this.props.postSectionComment(hearingSlug, sectionId, commentData);
+    return this.props.postSectionComment(hearingSlug, sectionId, commentData);
   }
 
   onVoteComment = (commentId, sectionId, isReply, parentId) => {

--- a/src/components/SortableCommentList.js
+++ b/src/components/SortableCommentList.js
@@ -29,18 +29,22 @@ export class SortableCommentListComponent extends Component {
       showLoader: false,
       collapseForm: false,
       shouldAnimate: false,
-      answers: this.props.section.questions.map(
-        question => ({
-          question: question.id,
-          type: question.type,
-          answers: []
-        })
-      )
+      answers: this._defaultAnswerState()
     };
 
     this.fetchMoreComments = throttle(this._fetchMoreComments).bind(this);
     this.handleReachBottom = this.handleReachBottom.bind(this);
     this.fetchComments = this.fetchComments.bind(this);
+  }
+
+  _defaultAnswerState() {
+    return this.props.section.questions.map(
+      question => ({
+        question: question.id,
+        type: question.type,
+        answers: []
+      })
+    );
   }
 
   _fetchMoreComments() {
@@ -109,7 +113,9 @@ export class SortableCommentListComponent extends Component {
     const commentData = {text, authorName, pluginData, geojson, label, images, answers, pinned};
 
     if (this.props.onPostComment) {
-      this.props.onPostComment(section.id, commentData);
+      this.props.onPostComment(section.id, commentData).then(() => {
+        this.setState({answers: this._defaultAnswerState});
+      });
     }
   }
 

--- a/src/views/FullscreenHearing/FullscreenHearingContainer.js
+++ b/src/views/FullscreenHearing/FullscreenHearingContainer.js
@@ -39,7 +39,7 @@ export class FullscreenHearingContainerComponent extends React.Component {
     const hearingSlug = match.params.hearingSlug;
     const {authCode} = parseQuery(location.search);
     const commentData = Object.assign({authCode}, sectionCommentData);
-    this.props.postSectionComment(hearingSlug, mainSection.id, commentData);
+    return this.props.postSectionComment(hearingSlug, mainSection.id, commentData);
   }
 
   onVoteComment = (commentId) => {


### PR DESCRIPTION
The change resets the `answer` part of a comment after a successful comment has been made. If not done this way, the backend will complain that the user is not allowed to vote twice.