### PR TITLE
Do not include images when editing comments

### DIFF
--- a/src/components/Hearing/Comment/index.js
+++ b/src/components/Hearing/Comment/index.js
@@ -73,7 +73,7 @@ class Comment extends React.Component {
     const commentData = {};
 
     forEach(data, (value, key) => {
-      if (key !== 'content') {
+      if (['content', 'images'].indexOf(key) === -1) {
         commentData[key] = value;
       }
     });


### PR DESCRIPTION
Note that the `handleSubmit`, even if places in the `Comment` component
only handles updates and not creation of comments.

If the image is included when editing a comment it will try to send the image URL and the not the image back to the backend. This will end up in a 400 error where the backend can't interpret the `image` field from the frontend.
Since there is no support for removing or editing just the image of a comment, this is the fastest way to let people edit comments with images at this point. In the future, if image replacing or removing is added, then this needs to be refactored to use an actual image.