### PR TITLE
#784 Alt-text must be added to the loggin button in mobile version

### DIFF
--- a/server/bundler.js
+++ b/server/bundler.js
@@ -45,8 +45,6 @@ export function applyCompilerMiddleware(server, compiler, settings) {
   debug("enabling dev-middleware");
   server.use(require('webpack-dev-middleware')(compiler, {
     publicPath: compiler.options.output.publicPath,
-    quiet: false,
-    noInfo: false,
     stats: {
       assets: false,
       chunkModules: false,

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -72,14 +72,19 @@ class Header extends React.Component {
       ];
     }
     return [
-      <Button
-        key="login"
-        className="user-menu login-link user-menu--unlogged"
-        onClick={() => userManager.signinRedirect({ui_locales: this.props.language})}
-      >
-        <Icon name="user-o" className="user-nav-icon" aria-hidden="true" />
-        <span className="user-name"><FormattedMessage id="login" /></span>
-      </Button>,
+      <FormattedMessage id="login">
+        {login => (
+          <Button
+            key="login"
+            aria-label={login}
+            className="user-menu login-link user-menu--unlogged"
+            onClick={() => userManager.signinRedirect({ui_locales: this.props.language})}
+          >
+            <Icon name="user-o" className="user-nav-icon" aria-hidden="true" />
+            <span className="user-name">{login}</span>
+          </Button>
+        )}
+      </FormattedMessage>
     ];
   }
 
@@ -112,12 +117,19 @@ class Header extends React.Component {
   contrastToggle() {
     if (config.enableHighContrast) {
       return (
-        <Button className="contrast-button" onClick={() => this.props.toggleContrast()}>
-          <Icon name="adjust" aria-hidden="true"/>
-          <FormattedMessage id="contrastTitle">
-            {text => <span className="contrast-title">{text}</span> }
-          </FormattedMessage>
-        </Button>
+        <FormattedMessage id="contrastTitle">
+          {text => (
+            <Button
+              key="text"
+              aria-label={text}
+              className="contrast-button"
+              onClick={() => this.props.toggleContrast()}
+            >
+              <Icon name="adjust"/>
+              <span className="contrast-title">{text}</span>
+            </Button>
+          )}
+        </FormattedMessage>
       );
     }
     return (


### PR DESCRIPTION
Added aria-label for navbars login and high-contrast buttons. Also fixed yarn dev command.