### PR TITLE
#782 Text alternative for Helsinki logo, which acts as a link, should be "Go to the home page"

### DIFF
--- a/cities/helsinki/i18n/en.json
+++ b/cities/helsinki/i18n/en.json
@@ -2,7 +2,7 @@
   "commentConditions": "All comments will be published {linkToDefinition} in the City of Helsinki online service {linkToLicense}. If you are not logged in, you may leave an anonymous comment. The comments may be moderated if they contain insulting or offensive language.",
   "fullscreenHeaderLogoAlt": "City of Helsinki logo",
   "footerLogoAlt": "City of Helsinki logo",
-  "headerLogoAlt": "City of Helsinki logo",
+  "headerLogoAlt": "Go to the home page",
   "copyrightText": "City of Helsinki",
   "footerCityLink": "www.hel.fi"
 }

--- a/cities/helsinki/i18n/fi.json
+++ b/cities/helsinki/i18n/fi.json
@@ -2,7 +2,7 @@
   "commentConditions": "Annetut kommentit julkaistaan {linkToDefinition} Helsingin kaupungin palvelussa {linkToLicense}. Tekstejä voidaan muokata loukkaavan tai muutoin törkeän kielenkäytön osalta.",
   "fullscreenHeaderLogoAlt": "Helsinki logo",
   "footerLogoAlt": "Helsinki logo",
-  "headerLogoAlt": "Helsinki logo",
+  "headerLogoAlt": "Siirry etusivulle",
   "copyrightText": "Helsingin kaupunki",
   "footerCityLink": "www.hel.fi"
 }

--- a/cities/helsinki/i18n/sv.json
+++ b/cities/helsinki/i18n/sv.json
@@ -2,7 +2,7 @@
   "commentConditions": "Uttryckta kommentarer publiceras {linkToDefinition} i Helsingfors stads tjänst {linkToLicense}. Du kan lämna din kommentar anonymt om du inte har loggat in. Dessutom redigeras texter vid behov på grund av kränkande eller annars osakligt språkbruk.",
   "fullscreenHeaderLogoAlt": "Helsingfors stads logo",
   "footerLogoAlt": "Helsingfors stads logo",
-  "headerLogoAlt": "Helsingfors stads logo",
+  "headerLogoAlt": "Gå till hemsidan",
   "copyrightText": "Helsingfors stad",
   "footerCityLink": "www.hel.fi"
 }


### PR DESCRIPTION
Added more informative headerLogoAlt translations for screen reader