### PR TITLE
Clear hearing form errors

### DIFF
--- a/src/components/admin/HearingEditor.js
+++ b/src/components/admin/HearingEditor.js
@@ -180,11 +180,11 @@ class HearingEditor extends React.Component {
 
     // true if one of the keys in localErrors contain entries
     // eslint-disable-next-line no-unused-vars
+    this.setState({errors: localErrors});
     const containsError = Object.entries(localErrors).some(([k, v]) => Object.entries(v).length > 0);
     if (!containsError) {
       return dispatch(callbackAction(hearing));
     }
-    this.setState({errors: localErrors});
     return notifyError(formatMessage({id: 'validationNotification'}));
   }
 


### PR DESCRIPTION
Previously all errors were visible even after successfully saving a hearing.

refs. KER-31