### PR TITLE
Allow copying a direct link to a hearing comment

### DIFF
--- a/assets/sass/kerrokantasi/_commentlist.scss
+++ b/assets/sass/kerrokantasi/_commentlist.scss
@@ -58,6 +58,10 @@
       border-left-color: $theme-primary-light;
     }
 
+    &__flagged > .hearing-comment__comment-wrapper {
+      border-left-color: $theme-danger-light;
+    }
+
     &__pin {
       flex-basis: 50%;
       flex-direction: row;

--- a/assets/sass/kerrokantasi/_commentlist.scss
+++ b/assets/sass/kerrokantasi/_commentlist.scss
@@ -222,6 +222,7 @@
       }
 
       .fa {
+        margin-left: 2px;
         margin-right: 2px;
       }
     }

--- a/src/components/Hearing/Comment/index.js
+++ b/src/components/Hearing/Comment/index.js
@@ -518,6 +518,7 @@ class Comment extends React.Component {
               && Array.isArray(data.subComments) && data.subComments.length > 0,
             'comment-animate': this.state.shouldAnimate,
             'hearing-comment__admin': isAdminUser,
+            'hearing-comment__flagged': this.canFlagComments() && data.flagged,
             'hearing-comment__is-pinned': this.props.data.pinned,
           }
         ])}

--- a/src/components/Hearing/Comment/index.js
+++ b/src/components/Hearing/Comment/index.js
@@ -13,7 +13,7 @@ import Answer from './Answer';
 import QuestionForm from '../../QuestionForm';
 
 import Icon from '../../../utils/Icon';
-import {notifyError} from '../../../utils/notify';
+import {notifyError, notifyInfo} from '../../../utils/notify';
 import forEach from 'lodash/forEach';
 import find from 'lodash/find';
 import getAttr from '../../../utils/getAttr';
@@ -81,6 +81,13 @@ class Comment extends React.Component {
     } else {
       notifyError("Kirjaudu sisään liputtaaksesi kommentin.");
     }
+  }
+
+  onCopyURL() {
+    // Build absolute URL for comment
+    const commentUrl = `${window.location.origin}${window.location.pathname}#comment-${this.props.data.id}`;
+    navigator.clipboard.writeText(commentUrl);
+    notifyInfo(`Linkki kommenttiion kopioitu leikepöydällesi.`);
   }
 
   toggleEditor(event) {
@@ -275,6 +282,12 @@ class Comment extends React.Component {
           </span>
         </OverlayTrigger>
       </div>
+      <Button
+        className="btn-sm hearing-comment-vote-link"
+        onClick={this.onCopyURL.bind(this)}
+      >
+        <Icon name="link" aria-hidden="true"/>
+      </Button>
       { this.canFlagComments() && !data.deleted &&
       <Button className="btn-sm hearing-comment-vote-link" onClick={this.onFlag.bind(this)}>
         <Icon

--- a/src/components/Hearing/Comment/index.js
+++ b/src/components/Hearing/Comment/index.js
@@ -282,12 +282,11 @@ class Comment extends React.Component {
           </span>
         </OverlayTrigger>
       </div>
-      <Button
-        className="btn-sm hearing-comment-vote-link"
-        onClick={this.onCopyURL.bind(this)}
-      >
+      {this.canFlagComments() &&
+      <Button className="btn-sm hearing-comment-vote-link" onClick={this.onCopyURL.bind(this)}>
         <Icon name="link" aria-hidden="true"/>
       </Button>
+      }
       { this.canFlagComments() && !data.deleted &&
       <Button className="btn-sm hearing-comment-vote-link" onClick={this.onFlag.bind(this)}>
         <Icon

--- a/src/components/Hearing/Comment/index.js
+++ b/src/components/Hearing/Comment/index.js
@@ -42,6 +42,7 @@ class Comment extends React.Component {
 
   componentDidMount = () => {
     if (this.state.shouldJumpTo && this.commentRef && this.commentRef.current && !this.state.scrollComplete) {
+      // Jump to this comment
       this.commentRef.current.scrollIntoView({
         behaviour: 'smooth',
         block: 'nearest',
@@ -50,6 +51,17 @@ class Comment extends React.Component {
         scrollComplete: true,
         shouldAnimate: true,
       });
+    } else if (
+      // Jump to child subcomment
+      this.props.jumpTo
+      && this.props.data.comments.includes(this.props.jumpTo)
+      && !this.props.data.loadingSubComments
+      && (
+        (Array.isArray(this.props.data.subComments) && this.props.data.subComments.length === 0)
+        || this.props.data.subComments === undefined
+      )
+    ) {
+      this.handleShowReplys();
     }
   };
 
@@ -498,6 +510,7 @@ class Comment extends React.Component {
         ])}
         onAnimationEnd={this.handleEndstAnimation}
         ref={this.commentRef}
+        id={`comment-${data.id}`}
       >
         <div className="hearing-comment__comment-wrapper">
           {this.renderCommentHeader(isAdminUser)}

--- a/src/components/SortableCommentList.js
+++ b/src/components/SortableCommentList.js
@@ -266,8 +266,11 @@ export class SortableCommentListComponent extends Component {
       hearingGeojson
     } = this.props;
 
-    // const mockSection = Object.assign({}, section);
-    // mockSection.questions = mockQuestions;
+    const urlFragmentCommentId = (
+      window.location.hash.startsWith('#comment-')
+        ? Number(window.location.hash.replace('#comment-', ''))
+        : null
+    );
 
     const showCommentList =
       section && sectionComments && get(sectionComments, 'results') && !isEmpty(sectionComments.results);
@@ -365,7 +368,7 @@ export class SortableCommentListComponent extends Component {
                   hearingId={hearingId}
                   intl={intl}
                   isLoading={this.state.showLoader}
-                  jumpTo={this.state.shouldAnimate && sectionComments.jumpTo}
+                  jumpTo={urlFragmentCommentId || (this.state.shouldAnimate && sectionComments.jumpTo)}
                   language={language}
                   nicknamePlaceholder={getAuthorDisplayName(user) || this.props.intl.formatMessage({id: "anonymous"})}
                   onDeleteComment={this.props.onDeleteComment}

--- a/src/utils/notify.js
+++ b/src/utils/notify.js
@@ -17,6 +17,13 @@ const errorOptions = {
   position: toast.POSITION.BOTTOM_RIGHT,
 };
 
+const infoOptions = {
+  autoClose: 2000,
+  type: toast.TYPE.INFO,
+  hideProgressBar: true,
+  position: toast.POSITION.BOTTOM_RIGHT,
+};
+
 export function alert(message, title = "Kerrokantasi") {
   if (typeof window !== 'undefined') {
     require("alertifyjs").alert(title,
@@ -70,5 +77,16 @@ export function localizedNotifySuccess(string) {
     toast.success(getMessage(string), successOptions); // add type: 'success' to options
   } else {
     toast.success('Toiminto onnistui.', successOptions); // add type: 'success' to options
+  }
+}
+
+
+export function notifyInfo(message) {
+  if (typeof window !== 'undefined') {
+    if (message) {
+      toast.success(message, infoOptions);
+    } else {
+      toast.success('Ok.', infoOptions);
+    }
   }
 }


### PR DESCRIPTION
- Opening a link that has a comment URL fragment e.g. `/hearing-slug#comment-{id}` highlights that comments and focuses user's window on the comment, even if it is a subcomment.
- Add a button to the top-right of a comment to copy a link to the comment, which is visible only to comment moderators
- Highlight flagged comments for organisation moderators

refs: KER-29