### PR TITLE
fix route component prop type to function instead of object

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -48,22 +48,22 @@ Redirector.propTypes = {
 const Routes = () => (
   <Suspense fallback={<LoadSpinner />}>
     <Switch>
-      <Route exact path="/" component={HomeContainer} />
-      <Route path="/silent-renew" component={SilentRenew} />
-      <Route path="/info" component={Info} />
-      <Route path="/callback" component={LoginCallback} />
-      <Route path="/callback/logout" component={LogoutCallback} />
-      <Route path="/user-hearings" component={UserHearings} />
-      <Route path="/user-profile" component={UserProfile} />
+      <Route exact path="/" component={props => <HomeContainer {...props} />} />
+      <Route path="/silent-renew" component={props => <SilentRenew {...props}/>} />
+      <Route path="/info" component={props => <Info {...props}/>} />
+      <Route path="/callback" component={props => <LoginCallback {...props} />} />
+      <Route path="/callback/logout" component={props => <LogoutCallback {...props} />} />
+      <Route path="/user-hearings" component={props => <UserHearings {...props} />} />
+      <Route path="/user-profile" component={props => <UserProfile {...props} />} />
       {config.showAccessibilityInfo && (
-        <Route path="/accessibility" component={AccessibilityInfo} />
+        <Route path="/accessibility" component={props => <AccessibilityInfo {...props} />} />
       )}
-      <Route path="/hearings/:tab" component={HearingsContainer} />
-      <Route path="/hearing/new" component={NewHearingContainer} />
-      <Route path="/hearing/:hearingSlug" component={Redirector} />
-      <Route path="/:hearingSlug/fullscreen" component={FullscreenHearingContainer} />
-      <Route path="/:hearingSlug/:sectionId" component={HearingContainer} />
-      <Route path="/:hearingSlug" component={HearingContainer} />
+      <Route path="/hearings/:tab" component={props => <HearingsContainer {...props} />} />
+      <Route path="/hearing/new" component={props => <NewHearingContainer {...props} />} />
+      <Route path="/hearing/:hearingSlug" component={props => <Redirector {...props} />} />
+      <Route path="/:hearingSlug/fullscreen" component={props => <FullscreenHearingContainer {...props} />} />
+      <Route path="/:hearingSlug/:sectionId" component={props => <HearingContainer {...props} />} />
+      <Route path="/:hearingSlug" component={props => <HearingContainer {...props} />} />
     </Switch>
   </Suspense>
 );


### PR DESCRIPTION
`react-router-dom` provides the `<Route />` component which in that version (`^4.3.1`) requires the `component` props as a function type. Therefore there is red warnings in browser's console.

```
Warning: Failed prop type: Invalid prop `component` of type `object` supplied to `Route`, expected `function`.
    in Route (created by Routes)
    in Routes (created by App)
    in main (created by App)
    in div (created by App)
    in IntlProvider (created by App)
    in App (created by Connect(App))
    in Connect(App) (created by Route)
    in Route (created by withRouter(Connect(App)))
    in withRouter(Connect(App))
    in ScrollToTop (created by Route)
    in Route (created by withRouter(ScrollToTop))
    in withRouter(ScrollToTop)
    in Router (created by ConnectedRouter)
    in ConnectedRouter
    in r
    in Provider
    in div
```

* this could be solved by updating the `react-router-dom` to newer version
  * this caused need for more refactoring, cause that library tends not to be backwards compatibilite 
* or updating the `component` prop to function