### PR TITLE
OGP meta tag modificaitons

### DIFF
--- a/server/Html.js
+++ b/server/Html.js
@@ -3,17 +3,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export default class Html extends React.Component {
-  getMeta() {
-    const {heroImageURL, hearingData} = this.props;
-    const hearingImage = hearingData && hearingData.main_image;
-    const hearingAbstract = hearingData && hearingData.abstract;
+  // Fetches site's default metadata, these are often overwritten
+  // with more specific values
+  getDefaultMeta() {
+    const { heroImageURL } = this.props;
     return {
       title: 'Kerrokantasi',
-      url: hearingImage ? hearingData.main_image.url : heroImageURL,
-      description: hearingAbstract ?
-        hearingData.abstract.fi :
-        `Helsingin kaupungin Kerrokantasi-palvelussa kaupunkilaisilta 
-        kerätään mielipiteitä valmistelussa olevista asioista.`
+      url: heroImageURL,
+      description: `Kaupungin Kerrokantasi-palvelussa kaupunkilaisilta 
+      kerätään mielipiteitä valmistelussa olevista asioista.`
     };
   }
   render() {
@@ -23,7 +21,6 @@ export default class Html extends React.Component {
       bundleSrc,
       content,
       head,
-      hearingData,
       heroImageURL,
       initialState,
       showAccessibilityInfo,
@@ -59,14 +56,13 @@ export default class Html extends React.Component {
     window.ENABLE_STRONG_AUTH = ${JSON.stringify(enableStrongAuth)}
     window.ADMIN_HELP_URL = ${JSON.stringify(adminHelpUrl)};
     `;
-    const {title, description, url} = this.getMeta();
+    const {title, description, url} = this.getDefaultMeta();
     return (
       <html lang="fi">
         <head>
           <meta charSet="utf-8"/>
           <meta httpEquiv="X-UA-Compatible" content="IE=edge"/>
           <meta content="width=device-width, initial-scale=1" name="viewport"/>
-          {hearingData && hearingData.title && <title>{hearingData.title.fi}</title>}
           {head ? head.meta.toComponent() : null}
           {head ? head.link.toComponent() : null}
           <meta property="og:title" content={title} />
@@ -93,7 +89,6 @@ Html.propTypes = {
   content: PropTypes.string,
   head: PropTypes.object,
   initialState: PropTypes.object,
-  hearingData: PropTypes.object,
   showAccessibilityInfo: PropTypes.bool,
   showSocialMediaSharing: PropTypes.bool,
   enableCookies: PropTypes.bool,

--- a/server/Html.js
+++ b/server/Html.js
@@ -12,7 +12,7 @@ export default class Html extends React.Component {
       url: hearingImage ? hearingData.main_image.url : heroImageURL,
       description: hearingAbstract ?
         hearingData.abstract.fi :
-        `Turun kaupungin Kerrokantasi-palvelussa kaupunkilaisilta 
+        `Helsingin kaupungin Kerrokantasi-palvelussa kaupunkilaisilta 
         kerätään mielipiteitä valmistelussa olevista asioista.`
     };
   }

--- a/src/utils/commonUtils.js
+++ b/src/utils/commonUtils.js
@@ -1,0 +1,7 @@
+export function html2text(html) {
+  const tag = document.createElement('div');
+  tag.innerHTML = html;
+  return tag.innerText;
+}
+
+export default { html2text };

--- a/src/views/AccessibilityInfo/index.js
+++ b/src/views/AccessibilityInfo/index.js
@@ -38,7 +38,13 @@ class AccessibilityInfo extends React.Component {
     const { intl } = this.props;
     return (
       <Grid className="accessibility-page">
-        <Helmet title={intl.formatMessage({ id: 'accessibilityPage' })} />
+        <Helmet 
+          title={intl.formatMessage({ id: 'accessibilityPage' })}
+          meta={[
+            {name: "description", content: intl.formatMessage({id: 'descriptionTag'})},
+            {property: "og:description", content: intl.formatMessage({id: 'descriptionTag'})}
+          ]}
+        />
         <Row>
           <Col md={8}>
             <div dangerouslySetInnerHTML={{ __html: pageContent }} />

--- a/src/views/Hearing/HearingContainer.js
+++ b/src/views/Hearing/HearingContainer.js
@@ -17,6 +17,7 @@ import { fetchHearingEditorMetaData } from '../../actions/hearingEditor';
 import { getHearingWithSlug } from '../../selectors/hearing';
 import { getUser } from '../../selectors/user';
 import {organizationShape} from "../../types";
+import { html2text } from '../../utils/commonUtils';
 
 const HearingEditor = lazy(() => import(/* webpackChunkName: "editor" */'../../components/admin/HearingEditor'));
 
@@ -86,7 +87,11 @@ export class HearingContainerComponent extends React.Component {
           <React.Fragment>
             <Helmet
               title={getAttr(hearing.title, language)}
-              meta={[{name: "description", content: getAttr(hearing.abstract, language)}]}
+              meta={[
+                {name: "description", content: html2text(getAttr(hearing.abstract, language))},
+                {property: "og:description", content: html2text(getAttr(hearing.abstract, language))},
+                {property: "og:image", content: hearing.main_image.url}
+              ]}
             />
             {(!isEmpty(user) && canEdit(user, hearing)) &&
               <Suspense fallback={<LoadSpinner />}>

--- a/src/views/Hearings/index.js
+++ b/src/views/Hearings/index.js
@@ -304,7 +304,13 @@ export class Hearings extends React.Component {
           <div className="container">
             <Row>
               <Col md={10} mdPush={1}>
-                <Helmet title={formatMessage({ id: 'allHearings' })} />
+                <Helmet
+                  title={formatMessage({ id: 'allHearings' })}
+                  meta={[
+                    {name: "description", content: formatMessage({ id: 'descriptionTag' })},
+                    {property: "og:description", content: formatMessage({ id: 'descriptionTag' })}
+                  ]}
+                />
                 <FormattedMessage id="allHearings">
                   {txt => <h1 className="page-title">{txt}</h1>}
                 </FormattedMessage>

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -83,7 +83,10 @@ export class Home extends React.Component {
               <Col xs={10} md={8} className="welcome-content">
                 <Helmet
                   title={formatMessage({id: 'welcome'})}
-                  meta={[{name: "description", content: formatMessage({id: 'descriptionTag'})}]}
+                  meta={[
+                    {name: "description", content: formatMessage({id: 'descriptionTag'})},
+                    {property: "og:description", content: formatMessage({id: 'descriptionTag'})}
+                  ]}
                 />
                 <h1>
                   <FormattedMessage id="welcome" />

--- a/src/views/Info/index.js
+++ b/src/views/Info/index.js
@@ -58,7 +58,13 @@ class Info extends React.Component {
     const {intl} = this.props;
     return (
       <div className="container">
-        <Helmet title={intl.formatMessage({ id: 'infoPage' })} />
+        <Helmet
+          title={intl.formatMessage({ id: 'infoPage' })}
+          meta={[
+            {name: "description", content: intl.formatMessage({id: 'descriptionTag'})},
+            {property: "og:description", content: intl.formatMessage({id: 'descriptionTag'})}
+          ]}
+        />
         <Row>
           <Col md={8}>
             <div dangerouslySetInnerHTML={{__html: content}}/>


### PR DESCRIPTION
Use `react-helmet` to manage OGP tags.

* remove hearing meta tag declarations in `Html.js`
* let views manage their own ogp tags
  * this provides multi language support and more dynamic labeling for hearings