### PR TITLE
Modify container to run on Openshift, with limited write permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,42 @@
-# ===============================================
-FROM helsinkitest/node:12-slim as staticbuilder
-# ===============================================
+# ==========================================
+FROM helsinkitest/node:14-slim as deployable
+# ==========================================
 
-# Offical image has npm log verbosity as info. More info - https://github.com/nodejs/docker-node#verbosity
+# Official image has npm log verbosity as info. More info - https://github.com/nodejs/docker-node#verbosity
 ENV NPM_CONFIG_LOGLEVEL warn
 
-# set our node environment, either development or production
-# defaults to production, compose overrides this to development on build and run
-ARG NODE_ENV=development
+ARG NODE_ENV=production
 ENV NODE_ENV $NODE_ENV
+
+# Hardcode $HOME to /app, as yarn will need to put some stray files inside $HOME
+# In Openshift $HOME would be / by default
+ENV HOME /app
+
+# Expose port 8086
+EXPOSE 8086
 
 # Yarn
 ENV YARN_VERSION 1.19.1
 RUN yarn policies set-version $YARN_VERSION
 
 USER root
-RUN apt-install.sh build-essential
+RUN bash /tools/apt-install.sh build-essential
 
-# Use non-root user
-USER appuser
+# Most files from source tree are needed at runtime
+COPY  . .
 
-# Install dependencies
-COPY --chown=appuser:appuser package.json yarn.lock /app/
-COPY --chown=appuser:appuser config_dev.toml.example /app/config_dev.toml
-RUN yarn && yarn cache clean --force
+# Install npm dependencies and build the bundle
+ENV PATH /app/node_modules/.bin:$PATH
+RUN yarn config set network-timeout 300000
+RUN yarn && yarn cache clean --force && yarn build
 
-# Copy all files
-COPY --chown=appuser:appuser . .
+# Allow minimal writes to get the frontend server running
+RUN chgrp 0 .yarn .babel.json && chmod g+w .yarn .babel.json
 
-# Compile bundle
-RUN yarn build
+RUN bash /tools/apt-cleanup.sh build-essential
 
-# Start express server
+# Run the frontend server using arbitrary user to simulate
+# Openshift when running using fe. Docker. Under actual
+# Openshift, the user will be random
+USER 158435:0
 CMD [ "yarn", "start" ]
-
-# Expose port 8086
-EXPOSE 8086


### PR DESCRIPTION
# Kerrokantasi-UI container compatibility with Openshift

Dockerfile: modify the build process such that the resulting image can run in Openshift. Essentially make sure that directories that need to be written are owned by group 0 and writable by that group. Image is also changed to run with said group 0.
