### PR TITLE
if base-url contains path it would be ignored in URL constructor

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -5,7 +5,7 @@ import qs from 'querystring';
 import urlUtil from 'url';
 import {getApiToken} from './selectors/user';
 
-function getApiURL(endpoint, params = null) {
+export function getApiURL(endpoint, params = null) {
   let url = (config.apiBaseUrl.replace(/\/$/g, '') + "/" + endpoint.replace(/^\//g, ''));
   if (!/\/$/.test(url)) url += "/";  // All API endpoints end with a slash
   if (params) {

--- a/src/components/CommentReportModal/CommentReportForm.js
+++ b/src/components/CommentReportModal/CommentReportForm.js
@@ -7,6 +7,7 @@ import Icon from "../../utils/Icon";
 import config from '../../config';
 import { connect } from "react-redux";
 import { FILE_FORMATS } from "./constants";
+import { getApiURL } from "../../api";
 
 
 class CommentReportForm extends React.Component {
@@ -32,7 +33,7 @@ class CommentReportForm extends React.Component {
 
     const accessToken = apiToken.apiToken;
     const targetFileFormat = Object.values(FILE_FORMATS).find(format => format.id === fileFormat);
-    const reportUrl = new URL(`/v1/hearing/${hearing.slug}${targetFileFormat.downloadEndpoint}`, config.apiBaseUrl);
+    const reportUrl = new URL(getApiURL(`/v1/hearing/${hearing.slug}${targetFileFormat.downloadEndpoint}`));
     reportUrl.search = new URLSearchParams({lang: language});
 
     fetch(reportUrl, {


### PR DESCRIPTION
Bugfix in cases where there is path provided in config for API base url. See example below.

```js
const base = "http://localhost:8000/test"
const url_1 = new URL(base + "/path");
const url_2 = new URL("/path", base);
```

```js
url_1 URL {
  href: 'http://localhost:8000/test/path',
  origin: 'http://localhost:8000',
  protocol: 'http:',
  username: '',
  password: '',
  host: 'localhost:8000',
  hostname: 'localhost',
  port: '8000',
  pathname: '/test/path',
  search: '',
  searchParams: URLSearchParams {},
  hash: '' }

url_2 URL {
  href: 'http://localhost:8000/path',
  origin: 'http://localhost:8000',
  protocol: 'http:',
  username: '',
  password: '',
  host: 'localhost:8000',
  hostname: 'localhost',
  port: '8000',
  pathname: '/path',
  search: '',
  searchParams: URLSearchParams {},
  hash: '' }
```