### PR TITLE
Allow configuring Helsinki-style API-token endpoint location

### DIFF
--- a/server/getSettings.js
+++ b/server/getSettings.js
@@ -53,6 +53,7 @@ const optionalKeys = [
   "openid_client_id",
   "openid_audience",
   "openid_authority",
+  "openid_apitoken_url",
   "enable_highcontrast",
   "admin_help_url",
 ];


### PR DESCRIPTION
This setting was missing from the list of ones to be picked up by nconf.