### PR TITLE
KER-137

### DIFF
--- a/src/components/Hearing/Section/SectionContainer.js
+++ b/src/components/Hearing/Section/SectionContainer.js
@@ -51,6 +51,7 @@ import {
 
 import {getUser} from '../../../selectors/user';
 import 'react-image-lightbox/style.css';
+import { getApiURL } from '../../../api';
 
 export class SectionContainerComponent extends React.Component {
   state = {
@@ -95,7 +96,7 @@ export class SectionContainerComponent extends React.Component {
   // downloads report excel with user's credentials
   handleReportDownload = (hearing, apiToken, language) => {
     const accessToken = apiToken.apiToken;
-    const reportUrl = config.apiBaseUrl + '/v1/hearing/' + hearing.slug + '/report';
+    const reportUrl = getApiURL('/v1/hearing/' + hearing.slug + '/report');
 
     fetch(reportUrl, {
       method: 'GET',
@@ -415,7 +416,7 @@ export class SectionContainerComponent extends React.Component {
     } = this.props;
 
     const userIsAdmin = !isEmpty(user) && canEdit(user, hearing);
-    const reportUrl = config.apiBaseUrl + '/v1/hearing/' + hearing.slug + '/report';
+    const reportUrl = getApiURL('/v1/hearing/' + hearing.slug + '/report');
     const mainSection = sections.find(sec => sec.type === SectionTypes.MAIN);
     const section = sections.find(sec => sec.id === match.params.sectionId) || mainSection;
 


### PR DESCRIPTION
The api call link was being created manually instead of using the method for generating api urls, this made the link generation fail incase of slash at the end of api url in config.

API linkki luotiin käyttäen configuraation apiBaseUrl parametria mutta tämä hajoitti linkin jos configuraatioon oli mennyt mukaan / urlin loppuun. Sovelluksesta kuitenkin löytyi generateApiUrl funktio jonka avulla linkin generoituu oikein siitä huolimatta onko configuraatiossa / vai ei.
