### PR TITLE
Convert end date 00:00 to 23:59

### DIFF
--- a/src/components/admin/HearingFormStep4.js
+++ b/src/components/admin/HearingFormStep4.js
@@ -21,6 +21,13 @@ import MultiLanguageTextField, {TextFieldTypes} from '../forms/MultiLanguageText
 import {hearingShape} from '../../types';
 import {addSection} from '../../actions/hearingEditor';
 
+const convertStartOfToEndOfDay = function convertToEndOfDay(datetime) {
+  const dt = moment(datetime);
+  if (dt.isValid() && dt.isSame(dt.clone().startOf('day'))) {
+    return dt.endOf('day');
+  }
+  return datetime;
+};
 
 class HearingFormStep4 extends React.Component {
   constructor(props) {
@@ -54,9 +61,10 @@ class HearingFormStep4 extends React.Component {
 
   onChangeEnd(datetime) {
     if (datetime.toISOString instanceof Function) {
-      this.props.onHearingChange("close_at", datetime.toISOString());
+      const dt = convertStartOfToEndOfDay(datetime);
+      this.props.onHearingChange("close_at", dt.toISOString());
     } else if (moment(datetime, 'DD-MM-YYYY', true).isValid()) {
-      const manualDate = moment(datetime, 'DD-MM-YYYY');
+      const manualDate = convertStartOfToEndOfDay(moment(datetime, 'DD-MM-YYYY'));
       this.props.onHearingChange("close_at", moment(manualDate, 'llll').toISOString());
     }
   }


### PR DESCRIPTION
Requested feature so that picking an end date defaults to end of day (23:59:59) instead of start of day (00:00:00). [react-datetime](https://github.com/arqex/react-datetime/#react-datetime) didn't seem to provide any good way of doing this. Therefore here's a proposed solution where we always convert an end datetime that isSame as start of day into end of day. An unfortunate side effect is that it is no longer possible to select "00:00" as the end time, the earliest possible time for the day is now "00:01". 

 Attempting to manually input "klo 00.00" will convert into "klo 23.59".
