### PR TITLE
add coverage script for cicd

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
-    "snyk-protect": "snyk protect"
+    "snyk-protect": "snyk protect",
+    "coverage": "jest --coverage --coverageReporters=cobertura"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add `yarn coverage` script that runs `jest` tests and outputs coverage report.