### PR TITLE
KER-110

### DIFF
--- a/src/components/OverviewMap.js
+++ b/src/components/OverviewMap.js
@@ -131,7 +131,7 @@ class OverviewMap extends React.Component {
           default:
           // TODO: Implement support for other geometries too (markers, square, circle)
             contents.push(
-              <GeoJSON data={geojson} key={JSON.stringify(geojson)}>{this.getPopupContent(hearing, geojson)}</GeoJSON>
+              <GeoJSON data={geojson} key={Math.random()}>{this.getPopupContent(hearing, geojson)}</GeoJSON>
             );
         }
         // contents.push(<GeoJSON key={id} data={geojson}>{content}</GeoJSON>);


### PR DESCRIPTION
Kartalla saattoi näkyä sulkeutuneita kyselyitä.

Syy: Default käsittely kartan renderöinnissä ei käyttänyt Math.random() arvoa avaimena vaan geojsonia. Geojson ei kuitenkaan ole uniikki vaan saattoi esiintyä useasti -> aiheutti virheen ja nämä toimivat kartalla tämän jälkeen satunnaisesti.
