### PR TITLE
KER-167

### DIFF
--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -18,7 +18,7 @@ export default function retrieveUserFromSession() {
         {nickname: get(democracyUserJSON, 'nickname')},
         {answered_questions: get(democracyUserJSON, 'answered_questions')},
         {favorite_hearings: get(democracyUserJSON, 'followed_hearings')},
-        {adminOrganizations: get(democracyUserJSON, 'admin_organizations', null)},
+        {adminOrganizations: get(democracyUserJSON, 'admin_organizations', [])},
         {hasStrongAuth: get(democracyUserJSON, 'has_strong_auth', false)});
       return dispatch(createAction('receiveUserData')(userWithOrganization));
     });

--- a/src/components/Hearing/Comment/index.js
+++ b/src/components/Hearing/Comment/index.js
@@ -401,7 +401,7 @@ class Comment extends React.Component {
    * If a user can edit their comment(s) render hyperlinks
    * @returns {Component|null}
    */
-  renderEditLinks = () => (
+  renderEditLinks = (canDelete) => (
     <div className="hearing-comment__edit-links">
       <a
         href=""
@@ -409,12 +409,15 @@ class Comment extends React.Component {
       >
         <FormattedMessage id="edit"/>
       </a>
-      <a
-        href=""
-        onClick={(event) => this.handleDelete(event)}
-      >
-        <FormattedMessage id="delete"/>
-      </a>
+      {canDelete &&
+        <a
+          href=""
+          onClick={(event) => this.handleDelete(event)}
+
+        >
+          <FormattedMessage id="delete"/>
+        </a>
+      }
     </div>
   );
 
@@ -544,6 +547,7 @@ class Comment extends React.Component {
   render() {
     const {data, canReply} = this.props;
     const canEdit = data.can_edit;
+    const canDelete = data.can_delete;
     const {editorOpen, isReplyEditorOpen} = this.state;
     const isAdminUser = this.props.data
       && (typeof this.props.data.organization === 'string' || Array.isArray(this.props.data.organization));
@@ -621,7 +625,7 @@ class Comment extends React.Component {
               )}
             </div>
           )}
-          {canEdit && !data.deleted && this.renderEditLinks()}
+          {canEdit && !data.deleted && this.renderEditLinks(canDelete)}
           <div className="hearing-comment__actions-bar">
             <div className="hearing-comment__reply-link">
               {!isReplyEditorOpen && canReply && this.renderReplyLinks()}


### PR DESCRIPTION
# KER-167

## Separated permissions for editing and deleting a comment.

### Is dependent on backend update for this issue. Users would lose ability to delete their own comments against current master backend branch.

Tested locally by editing Comment data via React Developer Tools and adding the can_delete to the data.

As a side note fixed a small issue with wrong type of default value for adminOrganizations.
