### PR TITLE
fix: matomo.js expects different tracker url compared to piwik.js

### DIFF
--- a/src/utils/matomo.js
+++ b/src/utils/matomo.js
@@ -14,10 +14,9 @@ const setupMatomo = () => {
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function () {
-    
-    
+    var tracker = config.matomoScriptFilename === 'matomo.js' ? 'matomo.php' : 'tracker.php';
     var u = config.matomoScriptUrl;
-    _paq.push(['setTrackerUrl', u + 'tracker.php']);
+    _paq.push(['setTrackerUrl', u + tracker]);
     _paq.push(['setSiteId', config.matomoSiteId]);
     var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
     g.type = 'text/javascript';


### PR DESCRIPTION
fix: matomo.js expects different tracker url compared to piwik.js

Felt like parametrisizing this part would be bit over configuring this so created a simple if-else variable.