### PR TITLE
KER-196: changed matomo_domains to string

### DIFF
--- a/config_dev.toml.example
+++ b/config_dev.toml.example
@@ -70,7 +70,7 @@ city_config="cities/helsinki"
 # If using Matomo for tracking, setup the matomo parameters here
 # 
 # matomo_cookie_domain="*.kerrokantasi.hel.fi"
-# matomo_domains=["*.kerrokantasi.hel.fi", "*.kerrokantasi.hel.fi"]
+# matomo_domains="*.kerrokantasi.hel.fi,*.kerrokantasi.hel.fi"
 # matomo_site_id=380
 
 

--- a/server/getSettings.js
+++ b/server/getSettings.js
@@ -34,7 +34,7 @@ const defaults = {
   // Should cookies to enabled
   enable_cookies: false,
   matomo_cookie_domain: '',
-  matomo_domains: [],
+  matomo_domains: '',
   matomo_site_id: '',
   matomo_script_url: '',
   matomo_script_filename: '',
@@ -59,6 +59,7 @@ const optionalKeys = [
   "enable_cookies",
   "matomo_cookie_domain",
   "matomo_domains",
+  "matomo_site_id",
   "matomo_script_url",
   "matomo_script_filename",
   "openid_client_id",

--- a/src/utils/matomo.js
+++ b/src/utils/matomo.js
@@ -6,9 +6,11 @@ const setupMatomo = () => {
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
   _paq.push(['setDocumentTitle', document.domain + '/' + document.title]);
 
+  var domains = config.matomoDomains.split(',');
+
   //_paq.push(['setCookieDomain', '*.kerrokantasi.hel.fi']);
   _paq.push(['setCookieDomain', config.matomoCookieDomain]);
-  _paq.push(['setDomains', config.matomoDomains]);
+  _paq.push(['setDomains', domains]);
   _paq.push(['setDoNotTrack', true]);
   _paq.push(['disableCookies']);
   _paq.push(['trackPageView']);


### PR DESCRIPTION
… because configMap does not support Array variables, instead parsing a string into array.
