### PR TITLE
KER-226 | Add instructions for using local API and Tunnistamo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,66 @@ docker compose up
 
 The web application is running at http://localhost:8086
 
+
+### Using local Tunnistamo instance for development with docker
+
+#### Set tunnistamo hostname
+
+Add the following line to your hosts file (`/etc/hosts` on mac and linux):
+
+    127.0.0.1 tunnistamo-backend
+
+#### Create a new OAuth app on GitHub
+
+Go to https://github.com/settings/developers/ and add a new app with the following settings:
+
+- Application name: can be anything, e.g. local tunnistamo
+- Homepage URL: http://tunnistamo-backend:8000
+- Authorization callback URL: http://tunnistamo-backend:8000/accounts/github/login/callback/
+
+Save. You'll need the created **Client ID** and **Client Secret** for configuring tunnistamo in the next step.
+
+#### Install local tunnistamo
+
+Clone https://github.com/City-of-Helsinki/tunnistamo/.
+
+Follow the instructions for setting up tunnistamo locally. Before running `docker compose up` set the following settings in tunnistamo roots `docker-compose.env.yaml`:
+
+- SOCIAL_AUTH_GITHUB_KEY: **Client ID** from the GitHub OAuth app
+- SOCIAL_AUTH_GITHUB_SECRET: **Client Secret** from the GitHub OAuth app
+
+After you've got tunnistamo running locally, ssh to the tunnistamo docker container:
+
+`docker compose exec django bash`
+
+and execute the following four commands inside your docker container:
+
+```bash
+./manage.py add_oidc_client -n kerrokantasi-ui -t "id_token token" -u "http://localhost:8086/callback" "http://localhost:8086/silent-callback" -i https://api.hel.fi/auth/kerrokantasi-ui -m github -s dev
+./manage.py add_oidc_client -n kerrokantasi-api -t "code" -u http://localhost:8080/pysocial/complete/tunnistamo/ -i https://api.hel.fi/auth/kerrokantasi -m github -s dev -c
+./manage.py add_oidc_api -n kerrokantasi -d https://api.hel.fi/auth -s email,profile -c https://api.hel.fi/auth/kerrokantasi
+./manage.py add_oidc_api_scope -an kerrokantasi -c https://api.hel.fi/auth/kerrokantasi -n "Kerrokantasi" -d"Lorem ipsum"
+./manage.py add_oidc_client_to_api_scope -asi https://api.hel.fi/auth/kerrokantasi -c https://api.hel.fi/auth/kerrokantasi-ui
+```
+
+#### Configure Tunnistamo to frontend
+
+Change the following configuration in `config_dev.toml`
+
+```
+kerrokantasi_api_base="http://localhost:8080"
+
+openid_client_id="https://api.hel.fi/auth/kerrokantasi-ui"
+openid_audience="https://api.hel.fi/auth/kerrokantasi"
+openid_authority="http://tunnistamo-backend:8000"
+openid_apitoken_url="http://tunnistamo-backend:8000/api-tokens/"
+```
+
+#### Install Kerrokantasi API locally
+
+Clone the repository (https://github.com/City-of-Helsinki/kerrokantasi). Follow the instructions for running kerrokantasi with docker and using local Tunnistamo.
+
+
 ### Plugins
 
 Questionnaires can make use of plugins. As of yet, their use case


### PR DESCRIPTION
This PR adds instructions for using a local API and Tunnistamo instances for development with docker.