### PR TITLE
Separate contact person fetching to different dispatch method

### DIFF
--- a/src/components/admin/HearingEditor.js
+++ b/src/components/admin/HearingEditor.js
@@ -34,6 +34,7 @@ import {
   sectionMoveUp,
   startHearingEdit,
   unPublishHearing,
+  fetchHearingEditorContactPersons,
 } from '../../actions/hearingEditor';
 import {deleteHearingDraft} from '../../actions/index';
 import HearingForm from './HearingForm';
@@ -63,6 +64,8 @@ class HearingEditor extends React.Component {
       errors: {},
       commentReportsOpen: false,
     };
+    const { fetchEditorContactPersons } = this.props;
+    fetchEditorContactPersons();
   }
 
   toggleCommentReports() {
@@ -309,7 +312,7 @@ class HearingEditor extends React.Component {
   }
 
   render() {
-    const {hearing, isNewHearing} = this.props;
+    const {hearing, isNewHearing, dispatch } = this.props;
     return (
       <div className="hearing-editor">
         {this.getHearingForm()}
@@ -319,7 +322,7 @@ class HearingEditor extends React.Component {
           <HearingToolbar
             hearing={hearing}
             onCloseHearing={this.onCloseHearing}
-            onEdit={() => this.props.dispatch(startHearingEdit())}
+            onEdit={() => dispatch(startHearingEdit())}
             onPublish={this.onPublish}
             onReportsClick={this.toggleCommentReports}
             onRevertPublishing={this.onUnPublish}
@@ -351,13 +354,22 @@ HearingEditor.propTypes = {
   language: PropTypes.string,
   isNewHearing: PropTypes.bool,
   intl: PropTypes.object,
+  fetchEditorContactPersons: PropTypes.func,
 };
+
+const mapDispatchToProps = dispatch => ({
+  fetchEditorContactPersons: () => dispatch(fetchHearingEditorContactPersons()),
+  dispatch,
+});
+
+const mapStateToProps = (state) => ({
+  show: EditorSelector.getShowForm(state),
+  language: state.language,
+  contactPersons: EditorSelector.getContactPersons(state),
+});
 
 export {HearingEditor as UnconnectedHearingEditor};
 
-const WrappedHearingEditor = connect((state) => ({
-  show: EditorSelector.getShowForm(state),
-  language: state.language
-}))(injectIntl(HearingEditor));
+const WrappedHearingEditor = connect(mapStateToProps, mapDispatchToProps)(injectIntl(HearingEditor));
 
 export default WrappedHearingEditor;

--- a/src/middleware/hearingEditor.js
+++ b/src/middleware/hearingEditor.js
@@ -31,12 +31,26 @@ export const normalizeReceiveEditorMetaData =
   () => (next: (action: FSA) => any) => (action: FSA) => {
     if (action.type === EditorActions.RECEIVE_META_DATA) {
       const labels = get(action, 'payload.labels');
-      const contacts = get(action, 'payload.contactPersons');
       const organizations = get(action, 'payload.organizations');
       const normalizedMetaData = {
         labels: normalize(fillFrontIds(labels), labelResultsSchema),
-        contactPersons: normalize(fillFrontIds(contacts), contactPersonResultsSchema),
         organizations: normalize(fillFrontIds(organizations), OrganizationResultsSchema),
+      };
+      next({
+        type: action.type,
+        payload: normalizedMetaData,
+      });
+    } else {
+      next(action);
+    }
+  };
+
+export const normalizeReceiveEditorContactPersons =
+  () => (next: (action: FSA) => any) => (action: FSA) => {
+    if (action.type === EditorActions.RECEIVE_CONTACT_PERSONS) {
+      const contacts = get(action, 'payload.contactPersons');
+      const normalizedMetaData = {
+        contactPersons: normalize(fillFrontIds(contacts), contactPersonResultsSchema),
       };
       next({
         type: action.type,
@@ -79,6 +93,7 @@ export const sectionFrontIds = () => (next: (action: FSA) => any) => (action: FS
 export default [
   sectionFrontIds,
   normalizeReceiveEditorMetaData,
+  normalizeReceiveEditorContactPersons,
   normalizeReceivedHearing,
   normalizeSavedHearing
 ];

--- a/src/reducers/hearingEditor/contactPersons.js
+++ b/src/reducers/hearingEditor/contactPersons.js
@@ -10,7 +10,7 @@ const CONTACTS = 'contactPersons';
 
 const byId = handleActions(
   {
-    [EditorActions.RECEIVE_META_DATA]: (state, { payload: { contactPersons } }) => {
+    [EditorActions.RECEIVE_CONTACT_PERSONS]: (state, { payload: { contactPersons } }) => {
       return contactPersons.entities.contactPersons ? contactPersons.entities.contactPersons : [];
     },
     [EditorActions.UPDATE_HEARING_AFTER_SAVE]: (state, { payload: { entities } }) => ({
@@ -23,7 +23,7 @@ const byId = handleActions(
 
 const all = handleActions(
   {
-    [EditorActions.RECEIVE_META_DATA]: (state, { payload: { contactPersons } }) =>
+    [EditorActions.RECEIVE_CONTACT_PERSONS]: (state, { payload: { contactPersons } }) =>
       contactPersons.result.map(key => key.toString()),
     [EditorActions.UPDATE_HEARING_AFTER_SAVE]: (state, { payload: { entities } }) => [
       ...new Set([...state, ...keys(entities[CONTACTS])]),

--- a/src/reducers/hearingEditor/index.js
+++ b/src/reducers/hearingEditor/index.js
@@ -20,6 +20,8 @@ const editorPending = handleActions({
   receiveHearingError: (state) => state - 1,
   [EditorActions.FETCH_META_DATA]: (state) => state + 1,
   [EditorActions.RECEIVE_META_DATA]: (state) => state - 1,
+  [EditorActions.FETCH_CONTACT_PERSONS]: (state) => state - 1,
+  [EditorActions.RECEIVE_CONTACT_PERSONS]: (state) => state + 1,
 }, 0);
 
 const editorIsSaving = handleActions({

--- a/src/views/Hearing/HearingContainer.js
+++ b/src/views/Hearing/HearingContainer.js
@@ -24,7 +24,7 @@ const HearingEditor = lazy(() => import(/* webpackChunkName: "editor" */'../../c
 export class HearingContainerComponent extends React.Component {
   constructor(props) {
     super(props);
-    const {fetchProjectsList, fetchHearing, fetchEditorMetaData, match: {params}, location} = this.props;
+    const {fetchProjectsList, fetchHearing, fetchEditorMetaData, match: {params}, location } = this.props;
     if (location.search.includes('?preview')) {
       // regex match to get the ?preview=key and substring to retrieve the key part
       fetchHearing(params.hearingSlug, location.search.match(/\?preview=([\w+-]+)/g)[0].substring(9));
@@ -76,7 +76,6 @@ export class HearingContainerComponent extends React.Component {
       hearingDraft,
       hearingLanguages,
       isLoading,
-      contactPersons,
       organizations,
       setLanguage
     } = this.props;
@@ -103,7 +102,6 @@ export class HearingContainerComponent extends React.Component {
                   labels={labels}
                   user={user}
                   isLoading={isLoading}
-                  contactPersons={contactPersons}
                   organizations={organizations}
                 />
               </Suspense>
@@ -140,7 +138,6 @@ HearingContainerComponent.propTypes = {
   hearingDraft: PropTypes.object,
   hearingLanguages: PropTypes.array,
   isLoading: PropTypes.bool,
-  contactPersons: PropTypes.array,
   organizations: PropTypes.arrayOf(organizationShape),
   fetchHearing: PropTypes.func,
   fetchEditorMetaData: PropTypes.func,
@@ -158,7 +155,6 @@ const mapStateToProps = (state, ownProps) => ({
   labels: HearingEditorSelector.getLabels(state),
   user: getUser(state),
   isLoading: HearingEditorSelector.getIsLoading(state),
-  contactPersons: HearingEditorSelector.getContactPersons(state),
   organizations: state.hearingEditor.organizations.all,
 });
 


### PR DESCRIPTION
Fetch contact person data when mounting `<HearingEditor />` component. The parent `<HearingContainer />` does not need the data from `/v1/contact_person/` endpoint.  Eg. fetch the data from endpoint `/v1/contact_person/` only when the user is admin or editor of the hearing.

* separate the `/v1/contact_person/` api call from the bundled dispatch method `fetchHearingEditorMetaData()`
* perform this dispatch in `<HearingEditor />` constructor