### PR TITLE
mock fetchEditorContactPersons function provided as a prop to component

### DIFF
--- a/__tests__/HearingEditor/HearingEditor.react-test.js
+++ b/__tests__/HearingEditor/HearingEditor.react-test.js
@@ -7,7 +7,7 @@ import {notifyError} from '../../src/utils/notify';
 jest.mock('../../src/utils/notify');
 
 const defaultProps = {
-  contactPersons: mockStore.hearing.mockHearing.data.contact_persons,
+  contactPersons: [],
   dispatch: jest.fn(),
   show: true,
   hearing: mockStore.hearing.mockHearing.data,
@@ -16,7 +16,7 @@ const defaultProps = {
   user: mockUser,
   language: 'fi',
   isNewHearing: true,
-  fetchEditorContactPersons: jest.fn(),
+  fetchEditorContactPersons: jest.fn().mockResolvedValue(mockStore.hearing.mockHearing.data.contact_persons),
 };
 
 describe('HearingEditor', () => {

--- a/__tests__/HearingEditor/HearingEditor.react-test.js
+++ b/__tests__/HearingEditor/HearingEditor.react-test.js
@@ -16,6 +16,7 @@ const defaultProps = {
   user: mockUser,
   language: 'fi',
   isNewHearing: true,
+  fetchEditorContactPersons: jest.fn(),
 };
 
 describe('HearingEditor', () => {


### PR DESCRIPTION
Fix failing test
```
Summary of all failing tests
FAIL __tests__/HearingEditor/HearingEditor.react-test.js
  ● HearingEditor › validateHearing

    TypeError: fetchEditorContactPersons is not a function

      66 |     };
      67 |     const { fetchEditorContactPersons } = this.props;
    > 68 |     fetchEditorContactPersons();
         |     ^
      69 |   }
      70 |
      71 |   toggleCommentReports() {

      at new fetchEditorContactPersons (src/components/admin/HearingEditor.js:68:5)
      at ReactShallowRenderer.render (node_modules/react-test-renderer/cjs/react-test-renderer-shallow.development.js:784:26)
      at renderElement (node_modules/enzyme-adapter-react-16/src/ReactSixteenAdapter.js:643:41)
      at renderElement (node_modules/enzyme-adapter-react-16/src/ReactSixteenAdapter.js:759:44)
      at fn (node_modules/enzyme-adapter-utils/src/Utils.js:100:18)
      at Object.render (node_modules/enzyme-adapter-react-16/src/ReactSixteenAdapter.js:759:37)
      at new render (node_modules/enzyme/src/ShallowWrapper.js:411:22)
      at shallow (node_modules/enzyme/src/shallow.js:10:10)
      at getWrapper (__tests__/HearingEditor/HearingEditor.react-test.js:23:19)
      at Object.getWrapper (__tests__/HearingEditor/HearingEditor.react-test.js:46:21)


Test Suites: 1 failed, 1 skipped, 51 passed, 52 of 53 total
Tests:       1 failed, 3 skipped, 384 passed, 388 total
Snapshots:   18 passed, 18 total
```