### PR TITLE
KER-277 Fix language from query string bug

### DIFF
--- a/src/middleware/language.js
+++ b/src/middleware/language.js
@@ -10,7 +10,7 @@ export const languageFromUrlMiddleware = store => next => action => {
     return next(action);
   }
   
-  const queryLang = action.payload.location ? parseQuery(action.payload.location.search).lang : '';
+  const queryLang = action.payload.search ? parseQuery(action.payload.search).lang : '';
   
   if (isEmpty(queryLang)) {
     store.dispatch(setLanguage('fi'));


### PR DESCRIPTION
Hotfix for a bug: [KER-277](https://helsinkisolutionoffice.atlassian.net/browse/KER-277)

So, getting language from query string didn't work. There was a bug on middleware that parses query string -> now fixed

[KER-277]: https://helsinkisolutionoffice.atlassian.net/browse/KER-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ