### PR TITLE
KER-276 Fix internal links

### DIFF
--- a/__tests__/InternalLink.react-test.jsx
+++ b/__tests__/InternalLink.react-test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { HashLink } from 'react-router-hash-link';
+import AnchorLink from 'react-anchor-link-smooth-scroll';
 
 import InternalLink from '../src/components/InternalLink';
 
@@ -19,17 +19,17 @@ describe('InternalLink', () => {
   }
 
   describe('renders', () => {
-    test('HashLink with correct default props', () => {
-      const link = getWrapper().find(HashLink);
+    test('AnchorLink with correct default props', () => {
+      const link = getWrapper().find(AnchorLink);
       expect(link).toHaveLength(1);
-      const to = `${window.location.pathname}${window.location.search}#${defaultProps.destinationId}`;
+      const href = `#${defaultProps.destinationId}`;
       expect(link.prop('className')).toBe('internal-link');
-      expect(link.prop('to')).toBe(to);
+      expect(link.prop('href')).toBe(href);
       expect(link.prop('children')).toEqual(<span>test link</span>);
     });
 
-    test('HashLink with correct className when prop srOnly is true', () => {
-      const link = getWrapper({ srOnly: true }).find(HashLink);
+    test('AnchorLink with correct className when prop srOnly is true', () => {
+      const link = getWrapper({ srOnly: true }).find(AnchorLink);
       expect(link).toHaveLength(1);
       expect(link.prop('className')).toBe('internal-link hidden-link');
     });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,11 +9,11 @@ import Helmet from 'react-helmet';
 import { withRouter } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
 import classNames from 'classnames';
-import { HashLink } from 'react-router-hash-link';
 
 import messages from './i18n';
 import Header from './components/Header';
 import Footer from './components/Footer';
+import InternalLink from './components/InternalLink';
 import { fetchApiToken } from './actions';
 import config from './config';
 import Routes from './routes';
@@ -77,14 +77,13 @@ class App extends React.Component {
       header = <Header slim={this.props.history.location.pathname !== '/'} history={this.props.history} />;
     }
     const mainContainerId = 'main-container';
-    const skipTo = `${this.props.location.pathname}${this.props.location.search}#${mainContainerId}`;
     return (
       <IntlProvider locale={locale} messages={messages[locale] || {}}>
         <div className={contrastClass}>
           {config.enableCookies && !isCookiebotEnabled() && <CookieBar language={locale} />}
-          <HashLink className='skip-to-main-content' to={skipTo}>
+          <InternalLink className='skip-to-main-content' destinationId={mainContainerId}>
             <FormattedMessage id='skipToMainContent' />
-          </HashLink>
+          </InternalLink>
           <Helmet titleTemplate='%s - Kerrokantasi' link={favlinks} meta={favmeta}>
             <html lang={locale} />
             {isCookiebotEnabled() && getCookieBotConsentScripts()}

--- a/src/components/Hearing/Section/SectionContainer.jsx
+++ b/src/components/Hearing/Section/SectionContainer.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/forbid-prop-types */
 /* eslint-disable react/no-danger */
 import React from 'react';
-import AnchorLink from 'react-anchor-link-smooth-scroll';
 import get from 'lodash/get';
 import findIndex from 'lodash/findIndex';
 import isEmpty from 'lodash/isEmpty';
@@ -15,6 +14,7 @@ import ContactCard from '../../ContactCard';
 import DeleteModal from '../../DeleteModal';
 import HearingMap from '../HearingMap';
 import Icon from '../../../utils/Icon';
+import InternalLink from '../../InternalLink';
 import Link from '../../LinkWithLang';
 import PluginContent from '../../PluginContent';
 import SectionAttachment from './SectionAttachment';
@@ -671,9 +671,9 @@ export class SectionContainerComponent extends React.Component {
               />
             </div>
             {isSectionCommentable(hearing, section, user) && (
-              <AnchorLink offset='100' href='#comments-section' className='hearing-subsection-write-comment-link'>
+              <InternalLink destinationId='comments-section' className='hearing-subsection-write-comment-link'>
                 <FormattedMessage id='headerWriteCommentLink' />
-              </AnchorLink>
+              </InternalLink>
             )}
           </div>
         )}

--- a/src/components/InternalLink.jsx
+++ b/src/components/InternalLink.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { HashLink } from 'react-router-hash-link';
+import AnchorLink from 'react-anchor-link-smooth-scroll';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-function InternalLink({ children, destinationId, srOnly }) {
-  const skipTo = `${window.location.pathname}${window.location.search}#${destinationId}`;
+function InternalLink({ children, destinationId, srOnly, className }) {
   return (
-    <HashLink className={srOnly ? 'internal-link hidden-link' : 'internal-link'} to={skipTo}>
+    <AnchorLink className={classNames(srOnly ? 'internal-link hidden-link' : 'internal-link', className)} href={`#${destinationId}`} offset='100'>
       {children}
-    </HashLink>
+    </AnchorLink>
   );
 }
 
@@ -19,6 +19,7 @@ InternalLink.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
   destinationId: PropTypes.string.isRequired,
   srOnly: PropTypes.bool,
+  className: PropTypes.string,
 };
 
 export default InternalLink;


### PR DESCRIPTION
Hotfix for a bug [KER-276](https://helsinkisolutionoffice.atlassian.net/browse/KER-276)

#Problem:
Internal links didn't work, but only in one place. I found out that the only working link didn't use the project's `InternalLink` -component but `react-anchor-link-smooth-scroll` npm component. Our `InternalLink` -component uses `react-router-hash-link` npm component under the hood. 

#Fix:
I changed `InternalLink` to use `react-anchor-link-smooth-scroll`

#Notes:
I searched for the reason why `react-router-hash-link` didn't work and found out from their [document](https://www.npmjs.com/package/react-router-hash-link) that this component works only with `ReactRouter`'s `BrowserRouter`, which we are not using

[KER-276]: https://helsinkisolutionoffice.atlassian.net/browse/KER-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ