### PR TITLE
feat: New progress bar to replace old bootstrap one

### DIFF
--- a/assets/sass/kerrokantasi/_common.scss
+++ b/assets/sass/kerrokantasi/_common.scss
@@ -252,3 +252,17 @@ a.list-group-item {
 .icon-adjustment {
   top: $font-size-base;
 }
+
+.progressBar-wrapper {
+  height: 1.4em;
+  position: relative;
+  width: 100%;
+  border-radius: 5px;
+  background: $light-gray;
+  .progressBar {
+    height: 100%;
+    position: relative;
+    border-radius: inherit;
+    background: blue;
+  }
+}

--- a/assets/sass/kerrokantasi/_common.scss
+++ b/assets/sass/kerrokantasi/_common.scss
@@ -264,5 +264,8 @@ a.list-group-item {
     position: relative;
     border-radius: inherit;
     background: blue;
+    &.in-viewport {
+      transition: width 2s;
+    }
   }
 }

--- a/cities/helsinki/assets/sass/hel/_hearing-page.scss
+++ b/cities/helsinki/assets/sass/hel/_hearing-page.scss
@@ -21,3 +21,7 @@
 .sortable-comment-list {
   background-color: $theme-secondary-light;
 }
+
+.progressBar {
+  background: $theme-primary-dark;
+}

--- a/cities/helsinki/assets/sass/hel/_hearing-page.scss
+++ b/cities/helsinki/assets/sass/hel/_hearing-page.scss
@@ -22,6 +22,7 @@
   background-color: $theme-secondary-light;
 }
 
-.progressBar {
+// Yes, the progressBar-wrapper is required beacuse if it's not included, the more specific definition of style is used.
+.progressBar-wrapper .progressBar {
   background: $theme-primary-dark;
 }

--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -1,13 +1,15 @@
 import React, {useState, useRef, useEffect} from 'react';
+import PropTypes from 'prop-types';
 
 function ProgressBar(props) {
     const [isIntersecting, setIsIntersecting] = useState(false);
-
     const [barWidth, setBarWidth] = useState(0);
-    const styleprops = {
-        width: barWidth + '%'
-    }
     const ref = useRef(null);
+    const width = props.now;
+    const styleprops = {
+        width: barWidth.toString().concat('%')
+    }
+    
 
     useEffect(() => {
         const observer = new IntersectionObserver(
@@ -23,22 +25,27 @@ function ProgressBar(props) {
         if (isIntersecting) {
           ref.current.querySelectorAll("div").forEach((el) => {
             el.classList.add("in-viewport");
-            setBarWidth(props.now);
+            setBarWidth(width);
           });
         }
-      }, [isIntersecting]);
+      }, [isIntersecting, width]);
 
     return (
         <div className="progressBar-wrapper" ref={ref}>
             <div 
                 className="progressBar"
-                aria-valuenow={props.now}
+                aria-valuenow={width}
                 aria-valuemin="0"
                 aria-valuemax="100"
-                style={styleprops}>
-            </div>
+                style={styleprops}
+            />
         </div>
     );
+    
+}
+
+ProgressBar.propTypes = {
+    now: PropTypes.number,
 }
 
 export default ProgressBar;

--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -1,12 +1,35 @@
-import React from 'react';
+import React, {useState, useRef, useEffect} from 'react';
 
 function ProgressBar(props) {
+    const [isIntersecting, setIsIntersecting] = useState(false);
 
+    const [barWidth, setBarWidth] = useState(0);
     const styleprops = {
-        width: props.now + '%'
+        width: barWidth + '%'
     }
+    const ref = useRef(null);
+
+    useEffect(() => {
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                setIsIntersecting(entry.isIntersecting);
+            }
+        );
+        observer.observe(ref.current);
+        return () => observer.disconnect();
+    }, [isIntersecting])
+
+    useEffect(() => {
+        if (isIntersecting) {
+          ref.current.querySelectorAll("div").forEach((el) => {
+            el.classList.add("in-viewport");
+            setBarWidth(props.now);
+          });
+        }
+      }, [isIntersecting]);
+
     return (
-        <div className="progressBar-wrapper">
+        <div className="progressBar-wrapper" ref={ref}>
             <div 
                 className="progressBar"
                 aria-valuenow={props.now}

--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+function ProgressBar(props) {
+
+    const styleprops = {
+        width: props.now + '%'
+    }
+    return (
+        <div className="progressBar-wrapper">
+            <div 
+                className="progressBar"
+                aria-valuenow={props.now}
+                aria-valuemin="0"
+                aria-valuemax="100"
+                style={styleprops}>
+            </div>
+        </div>
+    );
+}
+
+export default ProgressBar;

--- a/src/components/QuestionResults.jsx
+++ b/src/components/QuestionResults.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { v1 as uuid } from 'uuid';
-import { ProgressBar } from 'react-bootstrap';
+import ProgressBar from './ProgressBar';
 import { FormattedMessage } from 'react-intl';
 
 import getAttr from '../utils/getAttr';

--- a/src/components/QuestionResults.jsx
+++ b/src/components/QuestionResults.jsx
@@ -2,9 +2,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { v1 as uuid } from 'uuid';
-import ProgressBar from './ProgressBar';
 import { FormattedMessage } from 'react-intl';
 
+import ProgressBar from './ProgressBar';
 import getAttr from '../utils/getAttr';
 
 export const QuestionResultsComponent = ({ question, lang }) => {

--- a/src/components/admin/QuestionForm.jsx
+++ b/src/components/admin/QuestionForm.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { v1 as uuid } from 'uuid';
-import { ProgressBar } from 'react-bootstrap';
+import ProgressBar from '../ProgressBar';
 import { Button } from 'hds-react';
 import { FormattedMessage } from 'react-intl';
 

--- a/src/components/admin/QuestionForm.jsx
+++ b/src/components/admin/QuestionForm.jsx
@@ -3,10 +3,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { v1 as uuid } from 'uuid';
-import ProgressBar from '../ProgressBar';
 import { Button } from 'hds-react';
 import { FormattedMessage } from 'react-intl';
 
+
+import ProgressBar from '../ProgressBar';
 import MultiLanguageTextField, { TextFieldTypes } from '../forms/MultiLanguageTextField';
 import Icon from '../../utils/Icon';
 import getAttr from '../../utils/getAttr';


### PR DESCRIPTION
# Replacing old Bootstrap ProgressBar

## New custom ProgressBar implementation

### KER-299

----------------------------------------------------------------------------------------------

Reason behind change:
Removing old, deprecated React-bootstrap library from use and switching to HDS components. HDS did not offer suitable component for replacing the ProgressBar so instead created a custom component to solve this need.