### PR TITLE
ci: stop running commitlint against main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,6 @@ jobs:
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn lint
-      - name: Validate current commit (last commit) with commitlint
-        if: github.event_name == 'push'
-        run: yarn commitlint --from HEAD~1 --to HEAD --verbose
       - name: Validate PR commits with commitlint
         if: github.event_name == 'pull_request'
         run: yarn commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose


### PR DESCRIPTION
Release-please might create commit messages with longer lines than the limit of 72 chars, for example https://github.com/City-of-Helsinki/kerrokantasi-ui/commit/26307af785dd2d5769eac38a05f4bd2019194a9c. That shouldn't be a big issue. However, then [commitlint makes CI action fail](https://github.com/City-of-Helsinki/kerrokantasi-ui/actions/runs/8844826904/job/24287473208), which is not nice.

So disabled running commitlint against the main branch. When a commit is in the main branch it cannot be changed anyway 🙂