### PR TITLE
KER-351: Fix save hearing as copy

### DIFF
--- a/src/actions/__tests__/hearingEditor.test.jsx
+++ b/src/actions/__tests__/hearingEditor.test.jsx
@@ -33,7 +33,7 @@ describe('HearingEditor actions', () => {
     };
     const mockProcessedHearing = {
         id: '1',
-        title: {}, 
+        title: {},
         sections: [],
         labels: [],
         contact_persons: [],
@@ -92,7 +92,7 @@ describe('HearingEditor actions', () => {
             const response = actions.changeProject(projectId, projectLists)
             expect(response.payload).toEqual(expectedAction.payload.projectId);
         });
-      
+
         it('should create an action to update project language', () => {
             const languages = ['en', 'fi'];
             const expectedAction = {
@@ -101,7 +101,7 @@ describe('HearingEditor actions', () => {
             };
             expect(actions.updateProjectLanguage(languages)).toEqual(expectedAction);
         });
-      
+
         it('should create an action to activate a phase', () => {
             const phaseId = 'phase1';
             const expectedAction = {
@@ -127,7 +127,7 @@ describe('HearingEditor actions', () => {
             await store.dispatch(actions.fetchHearingEditorMetaData());
             expect(store.getActions()).toEqual(expectedActions);
         });
-        
+
         it('handles errors in fetching metadata', async () => {
             const error = new Error('Network Error');
             api.getAllFromEndpoint.mockRejectedValue(error);
@@ -138,7 +138,7 @@ describe('HearingEditor actions', () => {
             await store.dispatch(actions.fetchHearingEditorMetaData());
             expect(store.getActions()).toContainEqual(expectedActions[1]);
         });
-        
+
         it('adds an attachment and dispatches ADD_ATTACHMENT', async () => {
             const section = 'section1';
             const file = new Blob(['file content'], { type: 'text/plain' });
@@ -146,11 +146,14 @@ describe('HearingEditor actions', () => {
             const isNew = true;
             const attachment = { id: '123', title: 'New Attachment' };
             api.post.mockResolvedValue({ status: 200, json: () => Promise.resolve(attachment) });
-        
+
             const expectedActions = [
-                { type: EditorActions.ADD_ATTACHMENT, payload: { sectionId: section, attachment } }
+              {
+                type: EditorActions.ADD_ATTACHMENT,
+                payload: { sectionId: section, attachment: { ...attachment, isNew: true } },
+              },
             ];
-        
+
             await store.dispatch(actions.addSectionAttachment(section, file, title, isNew));
             expect(store.getActions()).toEqual(expectedActions);
         });
@@ -160,11 +163,11 @@ describe('HearingEditor actions', () => {
             const sectionId = 'sec123';
             const attachment = { id: 'att123' };
             api.apiDelete.mockResolvedValue({ status: 200 });
-        
+
             const expectedActions = [
                 { type: EditorActions.DELETE_ATTACHMENT, payload: { sectionId, attachment } }
             ];
-        
+
             await store.dispatch(actions.deleteSectionAttachment(sectionId, attachment));
             expect(store.getActions()).toEqual(expectedActions);
         });
@@ -175,7 +178,7 @@ describe('HearingEditor actions', () => {
                 type: EditorActions.DELETE_PHASE,
                 payload: { phaseId }
             };
-        
+
             store.dispatch(actions.deletePhase(phaseId));
             expect(store.getActions()).toContainEqual(expectedAction);
         });
@@ -189,11 +192,11 @@ describe('HearingEditor actions', () => {
             type: EditorActions.EDIT_SECTION,
             payload: { sectionID, field, value }
             };
-        
+
             store.dispatch(actions.changeSection(sectionID, field, value));
             expect(store.getActions()).toContainEqual(expectedAction);
         });
-    
+
         it('dispatches EDIT_QUESTION when editing a question', () => {
             const fieldType = 'text';
             const sectionId = 'sec123';
@@ -207,54 +210,54 @@ describe('HearingEditor actions', () => {
             store.dispatch(actions.editQuestion(fieldType, sectionId, questionId, optionKey, value));
             expect(store.getActions()).toContainEqual(expectedAction);
         });
-    });    
-    describe('saveHearingChanges', () => {      
+    });
+    describe('saveHearingChanges', () => {
         it('dispatches SAVE_HEARING_SUCCESS and navigates on successful save', async () => {
           const hearing = mockHearing;
           const hearingJSON = { id: '1', title: 'Original Title', slug: 'new-slug' };
           const response = { status: 200, json: () => Promise.resolve(hearingJSON) };
           api.put.mockResolvedValue(response);
-      
+
           const expectedActions = [
             { type: EditorActions.SAVE_HEARING, payload: { cleanedHearing: mockProcessedHearing } },
             { type: EditorActions.SAVE_HEARING_SUCCESS, payload: { hearing: hearingJSON } }
           ];
-      
+
           await store.dispatch(actions.saveHearingChanges(hearing));
-      
+
           expect(store.getActions()).toEqual(expect.arrayContaining(expectedActions));
           expect(push).toHaveBeenCalledWith(`/${hearingJSON.slug}?lang=${initialState.language}`);
         });
-      
+
         it('dispatches SAVE_HEARING_FAILED on API bad request', async () => {
           const hearing = mockHearing;
           const errors = { message: 'Invalid data' };
           const response = { status: 400, json: () => Promise.resolve(errors) };
           api.put.mockResolvedValue(response);
-      
+
           const expectedActions = [
             { type: EditorActions.SAVE_HEARING, payload: { cleanedHearing: mockProcessedHearing } },
             { type: EditorActions.SAVE_HEARING_FAILED, payload: { errors: { message: 'Invalid data' } } }
           ];
-      
+
           await store.dispatch(actions.saveHearingChanges(hearing));
-      
+
           expect(store.getActions()).toEqual(expect.arrayContaining(expectedActions));
         });
-      
+
         it('handles unauthorized error', async () => {
           const hearing = mockHearing;
           const response = { status: 401, json: () => Promise.resolve({}) };
           api.put.mockResolvedValue(response);
-      
+
           const expectedActions = [
             { type: EditorActions.SAVE_HEARING, payload: { cleanedHearing: mockProcessedHearing } }
           ];
-      
+
           await store.dispatch(actions.saveHearingChanges(hearing));
-      
+
           expect(store.getActions()).toEqual(expect.arrayContaining(expectedActions));
         });
       });
-        
+
 });

--- a/src/actions/hearingEditor.js
+++ b/src/actions/hearingEditor.js
@@ -389,10 +389,7 @@ export function addSectionAttachment(section, file, title, isNew) {
   // This method is a little different to exisitn methods as it uploads as soon as user selects file.
   return (dispatch) => {
     const url = '/v1/file';
-    let data = { file, title };
-    if (!isNew) {
-      data = { ...data, section };
-    }
+    const data = { file, title };
     return post(url, data)
       .then(checkResponseStatus)
       .then((response) => {

--- a/src/components/admin/HearingEditor.jsx
+++ b/src/components/admin/HearingEditor.jsx
@@ -31,6 +31,7 @@ import {
   publishHearing,
   saveAndPreviewHearingChanges,
   saveAndPreviewNewHearing,
+  saveAndPreviewHearingAsCopy,
   saveHearingChanges,
   sectionMoveDown,
   sectionMoveUp,
@@ -149,7 +150,7 @@ class HearingEditor extends React.Component {
 
   onSaveAsCopy() {
     const { hearing } = this.props;
-    this.validateHearing(hearing, saveAndPreviewNewHearing);
+    this.validateHearing(hearing, saveAndPreviewHearingAsCopy);
   }
 
   onSaveAndPreview() {

--- a/src/utils/__tests__/hearingEditor.test.js
+++ b/src/utils/__tests__/hearingEditor.test.js
@@ -1,0 +1,44 @@
+import { prepareSection } from '../hearingEditor';
+
+describe('prepareSection', () => {
+  it('should set the id property to empty in questions, options, images, and files', () => {
+    const section = {
+      id: 'sectionId',
+      questions: [
+        {
+          id: 'questionId',
+          options: [
+            { id: 'optionId1', value: 'Option 1' },
+            { id: 'optionId2', value: 'Option 2' },
+          ],
+        },
+      ],
+      images: [
+        { id: 'imageId1', url: 'image1.jpg' },
+        { id: 'imageId2', url: 'image2.jpg' },
+      ],
+      files: [
+        { id: 'fileId1', name: 'file1.pdf' },
+      ],
+    };
+
+    const preparedSection = prepareSection(section);
+
+    expect(preparedSection.id).toBe('');
+
+    preparedSection.questions.forEach((question) => {
+      expect(question.id).toBe('');
+
+      question.options.forEach((option) => {
+        expect(option.id).toBe('');
+      });
+    });
+
+    preparedSection.images.forEach((image) => {
+      expect(image.id).toBe('');
+    });
+
+    expect(preparedSection.files[0].id).toBe('');
+    expect(preparedSection.files[0].reference_id).toBe('fileId1');
+  });
+});

--- a/src/utils/hearingEditor.js
+++ b/src/utils/hearingEditor.js
@@ -7,11 +7,7 @@ import updeep from 'updeep';
 
 import { hearingSchema } from '../types';
 
-const ATTR_WITH_FRONT_ID = [
-  'sections',
-  'labels',
-  'contact_persons',
-];
+const ATTR_WITH_FRONT_ID = ['sections', 'labels', 'contact_persons'];
 
 /**
  *
@@ -19,23 +15,17 @@ const ATTR_WITH_FRONT_ID = [
  * @param {Function} idGenerator
  * @returns
  */
-export const fillFrontId = (
-  obj,
-  idGenerator,
-) => (
-  {
-    ...obj,
-    frontId: obj.frontId || obj.id || (idGenerator ? idGenerator() : uuid()),
-  }
-);
+export const fillFrontId = (obj, idGenerator) => ({
+  ...obj,
+  frontId: obj.frontId || obj.id || (idGenerator ? idGenerator() : uuid()),
+});
 /**
  *
  * @param {Object} thingz
  * @param {Function} idGenerator
  * @returns
  */
-export const fillFrontIds = (thingz, idGenerator) =>
-  thingz.map((thing) => fillFrontId(thing, idGenerator));
+export const fillFrontIds = (thingz, idGenerator) => thingz.map((thing) => fillFrontId(thing, idGenerator));
 
 /**
  *
@@ -45,18 +35,20 @@ export const fillFrontIds = (thingz, idGenerator) =>
  * @returns
  */
 export const normalizeEntitiesByFrontId = (data, entityKey, idGenerator) =>
-  normalize({
-    ...data,
-    [entityKey]: fillFrontIds(data[entityKey], idGenerator),
-  }, hearingSchema).entities[entityKey] || {};
+  normalize(
+    {
+      ...data,
+      [entityKey]: fillFrontIds(data[entityKey], idGenerator),
+    },
+    hearingSchema,
+  ).entities[entityKey] || {};
 
 /**
  *
  * @param {Hearing} hearing
  * @returns
  */
-export const normalizeHearing = (hearing) =>
-  normalize(hearing, hearingSchema);
+export const normalizeHearing = (hearing) => normalize(hearing, hearingSchema);
 
 /**
  *
@@ -66,10 +58,13 @@ export const normalizeHearing = (hearing) =>
  */
 export const fillFrontIdsForAttributes = (data, attrKeys = ATTR_WITH_FRONT_ID) => ({
   ...data,
-  ...attrKeys.reduce((filled, key) => ({
-    ...filled,
-    [key]: fillFrontIds(data[key]),
-  }), {})
+  ...attrKeys.reduce(
+    (filled, key) => ({
+      ...filled,
+      [key]: fillFrontIds(data[key]),
+    }),
+    {},
+  ),
 });
 
 /**
@@ -88,23 +83,25 @@ export const removeFrontId = (obj) => {
  * @param {Object} thingz
  * @returns
  */
-export const filterFrontIds = (thingz) =>
-  thingz.map(removeFrontId);
+export const filterFrontIds = (thingz) => thingz.map(removeFrontId);
 
 /**
  * @param {Object} data
  * @returns
  */
 export const filterFrontIdFromPhases = (data) => {
-  const cleanedPhases = data.project.phases.map(phase => {
+  const cleanedPhases = data.project.phases.map((phase) => {
     if (phase.frontId) return removeFrontId(updeep({ id: '' }, phase));
     return phase;
   });
-  return updeep({
-    project: {
-      phases: cleanedPhases
-    }
-  }, data);
+  return updeep(
+    {
+      project: {
+        phases: cleanedPhases,
+      },
+    },
+    data,
+  );
 };
 
 /**
@@ -118,44 +115,45 @@ export const filterFrontIdsFromAttributes = (data, attrKeys = ATTR_WITH_FRONT_ID
   if (data.project && data.project.phases) {
     filteredPhasesData = filterFrontIdFromPhases(data);
   }
-  return ({
+  return {
     ...filteredPhasesData,
-    ...attrKeys.reduce((filtered, key) => ({
-      ...filtered,
-      [key]: filterFrontIds(filteredPhasesData[key]),
-    }), {})
-  });
+    ...attrKeys.reduce(
+      (filtered, key) => ({
+        ...filtered,
+        [key]: filterFrontIds(filteredPhasesData[key]),
+      }),
+      {},
+    ),
+  };
 };
 
 const filterObjectByLanguages = (object, languages) => pickBy(object, (value, key) => includes(languages, key));
 
-const filterSectionsContentByLanguages = (sections, languages) => sections.map((section) => assign(
-  section,
-  {
-    abstract: filterObjectByLanguages(section.abstract, languages),
-    content: filterObjectByLanguages(section.content, languages),
-    images: section.images.map((image) => assign(image, filterObjectByLanguages(image.abstract))),
-    title: filterObjectByLanguages(section.title, languages)
-  }
-));
+const filterSectionsContentByLanguages = (sections, languages) =>
+  sections.map((section) =>
+    assign(section, {
+      abstract: filterObjectByLanguages(section.abstract, languages),
+      content: filterObjectByLanguages(section.content, languages),
+      images: section.images.map((image) => assign(image, filterObjectByLanguages(image.abstract))),
+      title: filterObjectByLanguages(section.title, languages),
+    }),
+  );
 
-export const filterTitleAndContentByLanguage = (data, languages) => assign(
-  data,
-  {
+export const filterTitleAndContentByLanguage = (data, languages) =>
+  assign(data, {
     abstract: filterObjectByLanguages(data.title, languages),
     main_image: data.main_image
       ? assign(data.main_image, filterObjectByLanguages(data.main_image.caption, languages))
       : null,
     title: filterObjectByLanguages(data.title, languages),
-    sections: filterSectionsContentByLanguages(data.sections, languages)
-  }
-);
+    sections: filterSectionsContentByLanguages(data.sections, languages),
+  });
 
 export const fillFrontIdsAndNormalizeHearing = flowRight([normalizeHearing, fillFrontIdsForAttributes]);
 
-export const getDocumentOrigin = () => (
+export const getDocumentOrigin = () =>
   // eslint-disable-next-line sonarjs/no-nested-template-literals
-  `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ''}/`);
+  `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ''}/`;
 
 export const moveSubsectionInArray = (array, index, delta) => {
   const newArray = array.slice();
@@ -176,15 +174,14 @@ export const initNewPhase = () => ({
   is_active: false,
   title: {},
   description: {},
-  schedule: {}
+  schedule: {},
 });
 
 export const initNewProject = () => ({
   id: '',
   title: {},
-  phases: []
+  phases: [],
 });
-
 
 /**
  * Parse through geojson features and round each coordinate to 6 decimals
@@ -230,8 +227,8 @@ export const parseCollection = (featureCollection) => {
       type: feature.type,
       geometry: {
         coordinates: normalizedCoordinates,
-        type: feature.geometry.type
-      }
+        type: feature.geometry.type,
+      },
     });
     return features;
   }, []);
@@ -299,4 +296,4 @@ export const prepareHearingForSave = (hearing) => {
  * @param {string} key
  * @returns {'error'|null}
  */
-export const getValidationState = (errors, key) => errors[key] ? 'error' : null;
+export const getValidationState = (errors, key) => (errors[key] ? 'error' : null);

--- a/src/utils/hearingEditor.js
+++ b/src/utils/hearingEditor.js
@@ -238,29 +238,24 @@ export const parseCollection = (featureCollection) => {
 export const prepareSection = (section) => ({
   ...section,
   id: '',
-  images: section.images.reduce((images, image) => [...images, { ...image, id: '', reference_id: image.id }], []),
-  files: section.files.reduce(
-    (files, file) => [...files, { ...file, id: file.isNew ? file.id : '', reference_id: file.isNew ? '' : file.id }],
-    [],
-  ),
-  questions: section.questions.reduce(
-    (questions, question) => [
-      ...questions,
-      {
-        ...question,
-        id: '',
-        options: question?.options.reduce((options, option) => [...options, { ...option, id: '' }], []),
-      },
-    ],
-    [],
-  ),
+  images: section.images.map((image) => ({ ...image, id: '', reference_id: image.id })),
+  files: section.files.map((file) => ({
+    ...file,
+    id: file.isNew ? file.id : '',
+    reference_id: file.isNew ? '' : file.id,
+  })),
+  questions: section.questions.map((question) => ({
+    ...question,
+    id: '',
+    options: question?.options.map((option) => ({ ...option, id: '' })),
+  })),
 });
 
 export const prepareHearingForSave = (hearing) => {
   // Scrub ids from sections and their children
   let preparedHearing = {
     ...hearing,
-    sections: hearing.sections.reduce((sections, section) => [...sections, prepareSection(section)], []),
+    sections: hearing.sections.map((section) => ({ ...prepareSection(section) })),
   };
 
   // Add geojson to cleanedHearing


### PR DESCRIPTION
TL;DR:
- Rename `cleanHearing` -> `prepareHearingForSave`
- Remove IDs from *all* objects when preparing hearing for saving, not just the section
- Prepare hearing only when creating a new hearing (either a fresh hearing or a copy of an existing hearing)
- Add new `reference_id` field in files/images on save
- Mark freshly uploaded files with `isNew`
- Don't assign uploaded files for hearing before saving

---

The "save as copy" action relies on some rather strange back-end logic where removing the ID is required only on some instances and, on the other hand, requires an ID in files. However, if you were creating a hearing the first time with a file uploaded to it, it causes problems.

To somewhat solve this problem, [a new field called `reference_id` can now be used with files and images](https://github.com/City-of-Helsinki/kerrokantasi/pull/490), which lets you base a file/image on an existing file/image (only when creating a new hearing, it currently does nothing if used for updating). This PR adds support for that.

Newly uploaded files are now marked with `isNew` to differentiate between existing instances and freshly uploaded files. This need for this comes up when you edit an existing hearing with a file and add a new file; now the hearing draft has both an existing file and a new file. If you save a copy in this state, the existing file needs to be copied while the new file doesn't need copying, you just want to assign it to the copy.

This PR also fixes another bug related to editing and uploading files; if you edit an existing hearing, add a file to a section and then leave without saving, the file is still added to the hearing despite the fact that the edits weren't saved. After the PR's changes, the hearing must be saved to finish adding the file to the hearing.

Related back-end PR (doesn't work without it): https://github.com/City-of-Helsinki/kerrokantasi/pull/490