### PR TITLE
fix: hearing toolbar wait for metadata KER-345

### DIFF
--- a/src/components/admin/HearingEditor.jsx
+++ b/src/components/admin/HearingEditor.jsx
@@ -323,12 +323,13 @@ class HearingEditor extends React.Component {
   }
 
   render() {
-    const { hearing, isNewHearing, dispatch } = this.props;
+    const { hearing, isNewHearing, dispatch, contactPersons, labels, organizations } = this.props;
+
     return (
       <div className='hearing-editor'>
         {this.getHearingForm()}
 
-        {!isNewHearing && (
+        {!isNewHearing && contactPersons.length && labels.length && organizations.length && (
           <>
             <HearingToolbar
               hearing={hearing}


### PR DESCRIPTION
# KER-345

Opening hearing editor can cause a blank page. This seems to happen if meta data has not yet been fully loaded before toolbar.