### PR TITLE
KER-377 Replace low contrast text-muted css variable

### DIFF
--- a/assets/sass/kerrokantasi/_commentlist.scss
+++ b/assets/sass/kerrokantasi/_commentlist.scss
@@ -166,7 +166,7 @@
     }
 
     &-date {
-      color: $text-muted;
+      color: var(--color-black-60);
       font-size: $font-size-small;
       position: relative;
 
@@ -174,7 +174,7 @@
         &:before {
           content: "";
           margin-right: 10px;
-          background-color: $text-muted;
+          background-color: var(--color-black-60);
           width: 4px;
           height: 4px;
           border-radius: 50%;
@@ -275,7 +275,7 @@
       font-size: $font-size-small;
 
       a {
-        color: $text-muted;
+        color: var(--color-black-60);
 
         &:hover,
         &:focus {
@@ -285,7 +285,7 @@
         & + a {
           margin-left: $grid-gutter-width/4;
           padding-left: $grid-gutter-width/4;
-          border-left: 1px solid $text-muted;
+          border-left: 1px solid var(--color-black-60);
         }
       }
     }

--- a/assets/sass/kerrokantasi/_common.scss
+++ b/assets/sass/kerrokantasi/_common.scss
@@ -184,7 +184,7 @@ a.list-group-item {
   color: $brand-info !important;
 }
 .Select-clear-zone {
-  color: $text-muted !important;
+  color: var(--color-black-60) !important;
 }
 
 .maintenance-notification {

--- a/assets/sass/kerrokantasi/_fullwidth-hearing.scss
+++ b/assets/sass/kerrokantasi/_fullwidth-hearing.scss
@@ -37,7 +37,7 @@
 
   &-times {
     margin-bottom: $line-height-computed / 2;
-    color: $text-muted;
+    color: var(--color-black-60);
     font-size: 1.4rem;
   }
 

--- a/assets/sass/kerrokantasi/_hearing-card.scss
+++ b/assets/sass/kerrokantasi/_hearing-card.scss
@@ -33,7 +33,7 @@
 
     .hearing-card-time {
       margin-bottom: $line-height-computed / 2;
-      color: $text-muted;
+      color: var(--color-black-60);
       font-size: $font-size-small;
 
       &.expires {
@@ -65,7 +65,7 @@
 
     .language-available-message {
       font-size: 90%;
-      color: $text-muted;
+      color: var(--color-black-60);
     }
   }
 }

--- a/assets/sass/kerrokantasi/_hearing-list.scss
+++ b/assets/sass/kerrokantasi/_hearing-list.scss
@@ -73,7 +73,7 @@
   }
 
   &-times {
-    color: $text-muted;
+    color: var(--color-black-60);
     font-size: $font-size-small;
     margin-bottom: $line-height-computed/1.5;
   }
@@ -153,7 +153,7 @@
     font-size: $font-size-large;
     font-weight: 400;
     margin: 0 $grid-gutter-width * 1.5 $grid-gutter-width/2 0;
-    color: $text-muted;
+    color: var(--color-black-60);
 
     span {
       margin-left: 0.15em;
@@ -201,7 +201,7 @@
     height: 80px;
 
     .Select-placeholder {
-      color: $text-muted;
+      color: var(--color-black-60);
     }
 
     #hearings-search-form {

--- a/assets/sass/kerrokantasi/_hearing-page.scss
+++ b/assets/sass/kerrokantasi/_hearing-page.scss
@@ -164,7 +164,7 @@
 
         .hearing-section-toggle-button-subtitle,
         .hearing-section-toggle-button-subtitle * {
-          color: $text-muted;
+          color: var(--color-black-60);
           text-decoration: none !important;
         }
       }
@@ -174,7 +174,7 @@
         font-size: $font-size-large;
         font-weight: normal;
         margin-top: $line-height-computed/2;
-        color: $text-muted;
+        color: var(--color-black-60);
         text-decoration: none;
       }
     }
@@ -182,7 +182,7 @@
     .fa-angle-right {
       width: $grid-gutter-width * 1.25;
       text-align: center;
-      color: $text-muted !important;
+      color: var(--color-black-60) !important;
       transition: transform 0.2s;
       margin-left: -$grid-gutter-width * 1.25;
       text-decoration: none !important;
@@ -333,7 +333,7 @@
       }
 
       .phase-schedule {
-        color: $text-muted;
+        color: var(--color-black-60);
       }
     }
   }
@@ -705,7 +705,8 @@
 
     .disabled {
       span {
-        border-color: $text-muted;
+        border-color: var(--color-black-60);
+        color: var(--color-black-60);
       }
     }
   }
@@ -719,7 +720,7 @@
     display: block;
     margin-bottom: $line-height-computed;
     text-transform: uppercase;
-    color: $text-muted;
+    color: var(--color-black-60);
     font-size: $font-size-large;
     font-weight: normal;
   }
@@ -739,7 +740,7 @@
 
   &:before {
     content: '';
-    background: $text-muted;
+    background: var(--color-black-60);
     width: 5px;
     height: 5px;
     border-radius: 50%;

--- a/assets/sass/kerrokantasi/_hearing-subsections.scss
+++ b/assets/sass/kerrokantasi/_hearing-subsections.scss
@@ -51,7 +51,7 @@
   }
 
   &-title-prefix {
-    color: $text-muted;
+    color: var(--color-black-60);
     font-size: $font-size-small;
     text-transform: uppercase;
   }


### PR DESCRIPTION
# Replace low contrast text-muted css variable

$text-muted css variable does not have enough contrast agains white background, replacing all occurances with HDS variable --color-black-60.

Before:
<img width="364" alt="Screenshot 2024-08-22 at 14 13 38" src="https://github.com/user-attachments/assets/87372663-368d-4da0-a9f4-4f15ee271314">

After:
<img width="370" alt="Screenshot 2024-08-22 at 14 13 17" src="https://github.com/user-attachments/assets/d9c6ba59-50d0-4489-93cf-4c7c949e00a6">
