### PR TITLE
fix: allow setting nodejs --max-old-space-size via environment variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.6.8",
   "main": "index.js",
   "scripts": {
-    "start": "NODE_ENV=production node server",
+    "start": "NODE_ENV=production; if test $NODE_MAX_MEMORY_MIB ; then node --max-old-space-size=$NODE_MAX_MEMORY_MIB server ; else node server ; fi",
     "build": "rm -rf ./dist && node compile",
     "fetch-plugins": "node deploy/fetch_plugins.js",
     "dev": "node server --dev --host 0.0.0.0",


### PR DESCRIPTION
Later nodejs versions default to using 50% of container allocated memory. This change adds an environment variable that can be used to override the default behaviour.

Refs: KER-382

Related: https://dev.azure.com/City-of-Helsinki/kerrokantasi/_git/kerrokantasi-pipelines/pullrequest/9586

