### PR TITLE
fix: fixed contacts not stacking on mobile sizes

### DIFF
--- a/assets/sass/kerrokantasi/_hearing-page.scss
+++ b/assets/sass/kerrokantasi/_hearing-page.scss
@@ -374,7 +374,7 @@
   flex-wrap: wrap;
   .hearing-contact {
     flex: 1;
-    max-width: 33.3%;
+    max-width: 100%;
     min-width: 25%;
     margin-bottom: $line-height-computed;
   }


### PR DESCRIPTION
Fixing contacts not stacking on mobile viewport sizes.