### PR TITLE
fix: fixed dependency array not having variables that require init

### DIFF
--- a/e2e/tests/pages/hearing.spec.js
+++ b/e2e/tests/pages/hearing.spec.js
@@ -39,7 +39,7 @@ test.describe('Hearing', () => {
   });
 
   test('should display comment count', async () => {
-    await expect(page.getByTestId('comment-summary')).toContainText(`Yhteensä ${hearing.n_comments} kommenttia`);
+    await expect(page.getByTestId('comment-summary')).toContainText(`Yhteensä ${hearing.n_comments} kommentti`);
   });
 
   test('should have Swedish link if available', async () => {

--- a/src/components/admin/HearingEditor.jsx
+++ b/src/components/admin/HearingEditor.jsx
@@ -87,7 +87,8 @@ const HearingEditor = (props) => {
         setShouldSubmit(false);
       }
     }
-  }, [shouldSubmit, editorErrors, errors, editorIsSaving, hearing.slug, language, navigate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldSubmit, editorErrors, errors, editorIsSaving, language, navigate]);
 
 
   /**


### PR DESCRIPTION
The hearingEditor caused an error due to hearing not being initialized before save action.