### PR TITLE
fix: fixes to commenting colors and options

### DIFF
--- a/src/components/Hearing/Comment/index.jsx
+++ b/src/components/Hearing/Comment/index.jsx
@@ -111,6 +111,8 @@ const Comment = (props) => {
     }
   };
 
+  const isCommentByAdmin = () => data.organization;
+
   const onCopyURL = () => {
     // Build absolute URL for comment
     const commentUrl = `${window.location.origin}${window.location.pathname}#comment-${props.data.id}`;
@@ -542,7 +544,7 @@ const Comment = (props) => {
           'hearing-comment__has-replys':
             data.subComments && Array.isArray(data.subComments) && data.subComments.length > 0,
           'comment-animate': state.shouldAnimate,
-          'hearing-comment__admin': adminUser,
+          'hearing-comment__admin': isCommentByAdmin(),
           'hearing-comment__flagged': canFlagComments() && data.flagged,
           'hearing-comment__is-pinned': props.data.pinned,
         },

--- a/src/components/admin/SectionForm.jsx
+++ b/src/components/admin/SectionForm.jsx
@@ -13,6 +13,7 @@ import { sectionShape } from '../../types';
 import { isSpecialSectionType } from '../../utils/section';
 import compressFile from '../../utils/images/compressFile';
 import fileToDataUri from '../../utils/images/fileToDataUri';
+import config from '../../config';
 
 const getFileTitle = (title, language) => {
   if (title?.[language] && typeof title[language] !== 'undefined') {
@@ -225,9 +226,9 @@ const SectionForm = ({
   const commentingOptions = [
     { value: 'open', label: formatMessage({ id: 'openCommenting' }) },
     { value: 'registered', label: formatMessage({ id: 'registeredUsersOnly' }) },
-    { value: 'strong', label: formatMessage({ id: 'registeredStrongOnly' }) },
+    ...config.enableStrongAuth ? [{ value: 'strong', label: formatMessage({ id: 'registeredStrongOnly' }) }] : [],
     { value: 'none', label: formatMessage({ id: 'noCommenting' }) },
-  ];
+  ];  
 
   const commentingInitialValue = section.commenting
     ? commentingOptions.find((option) => option.value === section.commenting)

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -38,11 +38,8 @@ const UserProfile = lazy(() => import(
  */
 const Redirector = () => {
   const { hearingSlug } = useParams();
-  return (
-  <div>
-    <Navigate to={`/${hearingSlug}`} />
-  </div>
-)};
+  return (<Navigate to={`/${hearingSlug}`} />);
+};
 
 const AppRoutes = () => (
   <Suspense fallback={<LoadSpinner />}>


### PR DESCRIPTION
Comments have yellow color to the border if they are made by admin.
When creating hearing, enabling commenting for strong auth users is now again behind config value.