### PR TITLE
fix: labels dropdown key field KER-422

### DIFF
--- a/src/components/admin/HearingFormStep1.jsx
+++ b/src/components/admin/HearingFormStep1.jsx
@@ -123,6 +123,7 @@ const HearingFormStep1 = ({
           <Combobox
             multiselect
             name='labels'
+            optionKeyField='id'
             defaultValue={hearing.labels.map((opt) => ({
               id: opt.id,
               title: getAttr(opt.label, language),


### PR DESCRIPTION
Combobox uses label as default key, which can cause problems with duplicate items.