### PR TITLE
fix: increased valid filetypes for geojson

### DIFF
--- a/src/utils/constants.jsx
+++ b/src/utils/constants.jsx
@@ -1,3 +1,3 @@
 export const ACCEPTED_IMAGE_TYPES = '.jpeg,.jpg,.png,.webp,.gif';
 export const ACCEPTED_FILE_TYPES = 'application/pdf';
-export const ACCEPTED_GEOJSON_TYPES = 'application/json';
+export const ACCEPTED_GEOJSON_TYPES = '.json, .geojson';


### PR DESCRIPTION
Missed the .geojson filetype from accepted filetypes for geojson map.