### PR TITLE
feat: add login e2e test KEH-98

### DIFF
--- a/e2e/constants.js
+++ b/e2e/constants.js
@@ -1,0 +1,8 @@
+import path from 'path';
+
+import dotenv from 'dotenv';
+
+dotenv.config({ path: path.resolve(__dirname, '../.env.local') });
+
+export const TEST_USER_EMAIL = process.env.E2E_TEST_USER_EMAIL ?? '';
+export const TEST_USER_PASSWORD = process.env.E2E_TEST_USER_PASSWORD ?? '';

--- a/e2e/tests/login.spec.js
+++ b/e2e/tests/login.spec.js
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+import { TEST_USER_EMAIL, TEST_USER_PASSWORD } from '../constants';
+import { login } from '../utils';
+
+test('Login', async ({ page }) => {
+  test.skip(
+    !TEST_USER_EMAIL || !TEST_USER_PASSWORD,
+    'No test user credentials provided'
+  );
+
+  await page.goto('/');
+
+  await login(page, TEST_USER_EMAIL, TEST_USER_PASSWORD);
+
+  await expect(page.getByRole('link', { name: 'Kerrokantasi' })).toBeVisible();
+});

--- a/e2e/utils.js
+++ b/e2e/utils.js
@@ -1,0 +1,13 @@
+/* eslint-disable import/prefer-default-export */
+import { expect } from '@playwright/test';
+
+export const login = async (page, email, password) => {
+  await page.getByRole('button', { name: 'Kirjaudu' }).click();
+
+  await expect(page.locator('.login-pf-page')).toBeVisible();
+
+  await page.getByRole('textbox', { name: 'Sähköposti' }).fill(email);
+  await page.getByRole('textbox', { name: 'Salasana' }).fill(password);
+
+  await page.getByRole('button', { name: 'Kirjaudu sisään' }).click();
+}


### PR DESCRIPTION
Add Login E2E test.

Branched from [KER-404 Vite](https://github.com/City-of-Helsinki/kerrokantasi-ui/tree/feat/KER-404-vite)

Pipelines changes: https://dev.azure.com/City-of-Helsinki/kerrokantasi/_git/kerrokantasi-pipelines/pullrequest/11175

[KEH-98](https://helsinkisolutionoffice.atlassian.net/browse/KEH-98)

[KEH-98]: https://helsinkisolutionoffice.atlassian.net/browse/KEH-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ