### PR TITLE
fix: hearing saveAndPreview fix for existing hearings

### DIFF
--- a/e2e/tests/pages/hearing.spec.js
+++ b/e2e/tests/pages/hearing.spec.js
@@ -3,12 +3,8 @@ import { expect, test } from '@playwright/test';
 const API_URL = process.env.API_URL || 'https://kerrokantasi.api.dev.hel.ninja';
 
 const fetchHearing = async () => {
-  /* const res = await fetch(`${API_URL}/v1/hearing/`);
-  const json = await res.json();
-  const openHearings = json.results.filter((hearing) => !hearing.closed);
-  */
-  const hearingId = 'NgHqPUpc4JD91uaMoyGYXSnC2z9YwkvO';
-  const hearing = await fetch(`${API_URL}/v1/hearing/${hearingId}/`);
+  const hearingSlug = 'kuuleminen-e2e-testausta-varten';
+  const hearing = await fetch(`${API_URL}/v1/hearing/${hearingSlug}/`);
 
   return hearing.json();
 };

--- a/e2e/tests/pages/hearing.spec.js
+++ b/e2e/tests/pages/hearing.spec.js
@@ -3,10 +3,11 @@ import { expect, test } from '@playwright/test';
 const API_URL = process.env.API_URL || 'https://kerrokantasi.api.dev.hel.ninja';
 
 const fetchHearing = async () => {
-  const res = await fetch(`${API_URL}/v1/hearing/`);
+  /* const res = await fetch(`${API_URL}/v1/hearing/`);
   const json = await res.json();
   const openHearings = json.results.filter((hearing) => !hearing.closed);
-  const hearingId = openHearings[0].id;
+  */
+  const hearingId = 'NgHqPUpc4JD91uaMoyGYXSnC2z9YwkvO';
   const hearing = await fetch(`${API_URL}/v1/hearing/${hearingId}/`);
 
   return hearing.json();
@@ -99,7 +100,11 @@ test.describe('Hearing', () => {
     const questionText = firstQuestion.text.fi;
     const options = firstQuestion.options.map((o) => o.text.fi);
     await expect(page.locator('.comment-form')).toContainText(questionText);
-    await expect(page.getByTestId('question-form-group').locator('.radio')).toContainText(options);
+    
+    // Check each option individually to ensure they are present in the form
+    for (const option of options) {
+      await expect(page.getByTestId('question-form-group')).toContainText(option);
+    }
   });
 
   test('user can successfully submit a comment', async () => {

--- a/src/actions/hearingEditor.js
+++ b/src/actions/hearingEditor.js
@@ -391,9 +391,11 @@ export function addSectionAttachment(section, file, title, isNew) {
 
 export function saveAndPreviewHearingChanges(hearing) {
   return (dispatch, getState) => {
-    const preparedHearing = prepareHearingForSave(hearing);
+    if (hearing.isNew) {
+      hearing = prepareHearingForSave(hearing);
+    }
     const cleanedHearing = filterTitleAndContentByLanguage(
-      filterFrontIdsFromAttributes(preparedHearing), getState().hearingEditor.languages
+      filterFrontIdsFromAttributes(hearing), getState().hearingEditor.languages
     );
     const preSaveAction = createAction(EditorActions.SAVE_HEARING, null, () => ({ fyi: 'saveAndPreview' }))({
       cleanedHearing,

--- a/src/actions/hearingEditor.js
+++ b/src/actions/hearingEditor.js
@@ -391,9 +391,6 @@ export function addSectionAttachment(section, file, title, isNew) {
 
 export function saveAndPreviewHearingChanges(hearing) {
   return (dispatch, getState) => {
-    if (hearing.isNew) {
-      hearing = prepareHearingForSave(hearing);
-    }
     const cleanedHearing = filterTitleAndContentByLanguage(
       filterFrontIdsFromAttributes(hearing), getState().hearingEditor.languages
     );


### PR DESCRIPTION
Editing hearing that was unpublished caused sections to have empty id's when sent to backend which in return caused new sections to be generated for hearing.