### PR TITLE
fix: login test requires both env variables KEH-98

### DIFF
--- a/e2e/tests/login.spec.js
+++ b/e2e/tests/login.spec.js
@@ -5,7 +5,7 @@ import { login } from '../utils';
 
 test('Login', async ({ page }) => {
   test.skip(
-    !TEST_USER_EMAIL || !TEST_USER_PASSWORD,
+    !TEST_USER_EMAIL && !TEST_USER_PASSWORD,
     'No test user credentials provided'
   );
 


### PR DESCRIPTION
login.spec.js should require both `TEST_USER_EMAIL` and `TEST_USER_PASSWORD` and not just one.