### PR TITLE
fix: fixed CC banner being unclosable if logged in as admin

### DIFF
--- a/assets/sass/kerrokantasi/_common.scss
+++ b/assets/sass/kerrokantasi/_common.scss
@@ -276,3 +276,8 @@ a.list-group-item {
     }
   }
 }
+
+.hds-cc__target {
+  z-index: 1005;
+  position: fixed;
+}


### PR DESCRIPTION
Cookiebanner was not closable if you didn't close it before logging in as the buttons got stuck under the admin bar.