### PR TITLE
fix: corrected notification type names

### DIFF
--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -13,7 +13,7 @@ import { mockStore as mockData, mockUser } from '../../test-utils';
 vi.mock('../hooks/useNotifications', () => ({
   default: vi.fn().mockReturnValue({
     notifications: [],
-    visibleTypes: ['error', 'warning', 'info'],
+    visibleTypes: ['error', 'alert', 'info'],
     isLoading: false,
     error: null
   })

--- a/src/hooks/__tests__/useNotifications.test.jsx
+++ b/src/hooks/__tests__/useNotifications.test.jsx
@@ -77,7 +77,7 @@ describe('useNotifications', () => {
     ]);
 
     // Check if visibleTypes is correct for home page
-    expect(result.current.visibleTypes).toEqual(['error', 'warning', 'info']);
+    expect(result.current.visibleTypes).toEqual(['error', 'alert', 'info']);
   });
 
   it('should show only error notifications on non-home pages', async () => {

--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -42,7 +42,7 @@ export const useNotifications = (language) => {
   // Convert visibleTypeRules to an array of notification types
   const visibleTypes = useMemo(() => {
     if (visibleTypeRules === 'all') {
-      return ['error', 'warning', 'info'];
+      return ['error', 'alert', 'info'];
     }
     return [visibleTypeRules];
   }, [visibleTypeRules]);


### PR DESCRIPTION
Notifications had wrong name for alerts (had used warnings).
