### PR TITLE
KER-601 | show existing comments when commenting is not ongoing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "engines": {
     "node": ">=22.13.1"
   },
+  "packageManager": "yarn@1.22.22",
   "scripts": {
     "app:version": "echo \"$npm_package_version\"",
     "start": "if test $NODE_MAX_MEMORY_MIB ; then node --max-old-space-size=$NODE_MAX_MEMORY_MIB yarn update-runtime-env && vite ; else yarn update-runtime-env && vite ; fi",

--- a/src/components/QuestionForm/__tests__/QuestionForm.test.jsx
+++ b/src/components/QuestionForm/__tests__/QuestionForm.test.jsx
@@ -60,7 +60,7 @@ describe('<QuestionForm />', () => {
     const onChange = vi.fn();
     renderComponent({ onChange });
 
-    userEvent.click(screen.getByLabelText('fi test one'));
+    await userEvent.click(screen.getByLabelText('fi test one'));
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(10, TYPE_SINGLE_CHOICE, 20);
     });
@@ -104,7 +104,7 @@ describe('<QuestionForm />', () => {
 
     renderComponent({ question, onChange });
 
-    userEvent.click(screen.getByLabelText('fi test one'));
+    await userEvent.click(screen.getByLabelText('fi test one'));
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(10, TYPE_MULTIPLE_CHOICE, 20);
     });

--- a/src/components/RichTextEditor/Iframe/__tests__/IframeCopyPasteField.test.jsx
+++ b/src/components/RichTextEditor/Iframe/__tests__/IframeCopyPasteField.test.jsx
@@ -33,7 +33,7 @@ describe('<IframeSelectField />', () => {
 
     const user = userEvent.setup();
 
-    user.type(input, 'test');
+    await user.type(input, 'test');
 
     await waitFor(() => expect(input.value).toBe('test'));
   });

--- a/src/components/RichTextEditor/__tests__/RichTextModalTextField.test.jsx
+++ b/src/components/RichTextEditor/__tests__/RichTextModalTextField.test.jsx
@@ -45,7 +45,7 @@ describe('<RichTextModalTextField />', () => {
 
     const user = userEvent.setup();
 
-    user.type(input, 'test');
+    await user.type(input, 'test');
 
     await waitFor(() => expect(handleInputChangeMock).toHaveBeenCalled());
 

--- a/src/components/SortableCommentList.jsx
+++ b/src/components/SortableCommentList.jsx
@@ -421,7 +421,7 @@ const SortableCommentListComponent = ({
 
   return (
     <div>
-      {section.commenting !== 'none' && (
+      {(section.commenting !== 'none' || showCommentList) && (
         <div className='sortable-comment-list'>
           {closed && section.questions.length >= 1 && (
             <div


### PR DESCRIPTION
## Summary
This PR fixes comment visibility in closed/non-commenting sections.

If a section already has comments, the comment section is now rendered
even when commenting is set to none. This keeps previously added comments
visible instead of hiding them.

## Main change
- Render existing comments when comments exist, regardless of commenting
  mode being none.
- Prevents old discussion context from disappearing in read-only state.

## Extra changes in branch
- Add packageManager field to package metadata.
- Await userEvent.click in tests to reduce async test flakiness.

Refs: KER-601