### PR TITLE
fix: keyboard navigation KER-597 

### DIFF
--- a/src/components/RichTextEditor/index.jsx
+++ b/src/components/RichTextEditor/index.jsx
@@ -11,7 +11,6 @@ import {
   AtomicBlockUtils,
   Modifier,
   SelectionState,
-  getDefaultKeyBinding,
 } from 'draft-js';
 import Editor, { composeDecorators } from '@draft-js-plugins/editor';
 import createImagePlugin from '@draft-js-plugins/image';
@@ -258,7 +257,6 @@ class RichTextEditor extends React.Component {
     this.onURLChange = this.onURLChange.bind(this);
     this.onBlur = this.onBlur.bind(this);
     this.handleKeyCommand = this.handleKeyCommand.bind(this);
-    this.onTab = this.onTab.bind(this);
     this.toggleBlockType = this.toggleBlockType.bind(this);
     this.toggleInlineStyle = this.toggleInlineStyle.bind(this);
     this.promptForLink = this.promptForLink.bind(this);
@@ -332,10 +330,6 @@ class RichTextEditor extends React.Component {
 
   /* EVENT CONTROLS */
   handleKeyCommand(command) {
-    if (command === 'custom-tab') {
-      this.onTab();
-      return true;
-    }
     const { editorState } = this.state;
     const newState = RichUtils.handleKeyCommand(editorState, command);
     if (newState) {
@@ -343,11 +337,6 @@ class RichTextEditor extends React.Component {
       return true;
     }
     return false;
-  }
-
-  onTab(event) {
-    const maxDepth = 4;
-    this.onChange(RichUtils.onTab(event, this.state.editorState, maxDepth));
   }
 
   onChange(editorState) {
@@ -424,14 +413,6 @@ class RichTextEditor extends React.Component {
       return formatMessage({ id: this.props.placeholderId });
     }
     return '';
-  }
-
-  myKeyBindingFn(e) {
-    if (e.keyCode === 9) {
-      return 'custom-tab';
-    }
-
-    return getDefaultKeyBinding(e);
   }
 
   removeLink(event) {
@@ -838,7 +819,6 @@ class RichTextEditor extends React.Component {
             handleKeyCommand={this.handleKeyCommand}
             onChange={this.onChange}
             onBlur={this.onBlur}
-            keyBindingFn={this.myKeyBindingFn}
             stripPastedStyles
             placeholder={this.getPlaceholder()}
             ref={this.editorRef}

--- a/src/components/admin/HearingForm.jsx
+++ b/src/components/admin/HearingForm.jsx
@@ -83,15 +83,19 @@ const HearingForm = ({
 
   const intl = useIntl();
 
-  const nextStep = () => {
-    const next = parseInt(currentStep, 10) + 1;
-    const nextAccordion = stepRefs.current[currentStep];
+  const nextStep = (stepNumber) => {
+    const next = parseInt(stepNumber, 10) + 1;
+    const nextAccordion = stepRefs.current[next - 1];
+    const nextToggle = nextAccordion.current?.querySelector(ACCORDION_TOGGLE);
+    const isNextOpen = nextToggle?.getAttribute('aria-expanded') === 'true';
+
+    if (nextAccordion.current && nextToggle && !isNextOpen) {
+      nextToggle.click();
+    }
 
     if (nextAccordion.current) {
-      nextAccordion.current.querySelector(ACCORDION_TOGGLE).click();
-
       setTimeout(
-        () => nextAccordion.current?.scrollIntoView({ behaviour: 'smooth' }),
+        () => nextAccordion.current?.scrollIntoView({ behavior: 'smooth' }),
         250
       );
     }
@@ -189,7 +193,7 @@ const HearingForm = ({
             initSingleChoiceQuestion={initSingleChoiceQuestion}
             labels={labels}
             language={language}
-            onContinue={nextStep}
+            onContinue={() => nextStep(stepNumber)}
             onAddMapMarker={onAddMapMarker}
             onAddMapMarkersToCollection={onAddMapMarkersToCollection}
             onCreateMapMarker={onCreateMapMarker}

--- a/src/components/admin/HearingForm.jsx
+++ b/src/components/admin/HearingForm.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable sonarjs/no-nested-functions */
 import React, {
   createRef,
   useCallback,
@@ -103,22 +102,21 @@ const HearingForm = ({
     setCurrentStep(next);
   };
 
-  const onToggleClick = useCallback(
-    ($this, stepNumber) => {
-      setTimeout(() => {
-        const isOpen = $this.getAttribute('aria-expanded') === 'true';
+  const onToggleClick = useCallback(($this, stepNumber) => {
+    setTimeout(() => {
+      const isOpen = $this.getAttribute('aria-expanded') === 'true';
 
-        if (currentStep === stepNumber) {
-          return;
-        }
+      if (isOpen) {
+        setCurrentStep((previousStep) => {
+          if (previousStep === stepNumber) {
+            return previousStep;
+          }
 
-        if (isOpen) {
-          setCurrentStep(stepNumber);
-        }
-      }, 500);
-    },
-    [currentStep]
-  );
+          return stepNumber;
+        });
+      }
+    }, 500);
+  }, []);
 
   useEffect(() => {
     if (show) {
@@ -127,23 +125,24 @@ const HearingForm = ({
         node: step.current.querySelector(ACCORDION_TOGGLE),
       }));
 
-      toggles.forEach((item) => {
+      const listeners = toggles.map((item) => ({
+        ...item,
+        handler: () => onToggleClick(item.node, item.stepNumber),
+      }));
+
+      listeners.forEach((item) => {
         if (!item.node) {
           return;
         }
-        item.node.addEventListener('click', () =>
-          onToggleClick(item.node, item.stepNumber)
-        );
+        item.node.addEventListener('click', item.handler);
       });
 
       return () => {
-        toggles.forEach((item) => {
+        listeners.forEach((item) => {
           if (!item.node) {
             return;
           }
-          item.node.removeEventListener('click', () =>
-            onToggleClick(item.node, item.stepNumber)
-          );
+          item.node.removeEventListener('click', item.handler);
         });
       };
     }

--- a/src/components/admin/HearingFormStep1.jsx
+++ b/src/components/admin/HearingFormStep1.jsx
@@ -39,32 +39,70 @@ const HearingFormStep1 = ({
   const intl = useIntl();
   const dispatch = useDispatch();
 
+  const getItemId = (item) =>
+    typeof item === 'object' && item !== null ? item.id : item;
+
   const [showLabelModal, setShowLabelModal] = useState(false);
   const [contactInfo, setContactInfo] = useState({});
   const [showContactModal, setShowContactModal] = useState(false);
-  const [selectedLabels, setSelectedLabels] = useState(
-    hearing?.labels?.map(({ id }) => id) || []
-  );
-  const [selectedContacts, setSelectedContacts] = useState(
-    hearing?.contact_persons?.filter(Boolean)?.map((person) => person?.id) || []
-  );
+  const selectedLabelIds = (hearing?.labels || []).map(getItemId).filter(Boolean);
+  const selectedContactIds = (hearing?.contact_persons || [])
+    .map(getItemId)
+    .filter(Boolean);
 
-  const onLabelsChange = (labels) => {
+  const getLabelSelectValue = () =>
+    (hearing.labels || [])
+      .map((item) => {
+        const option =
+          typeof item === 'object'
+            ? item
+            : labelOptions.find((label) => label.id === item);
+
+        if (!option) {
+          return null;
+        }
+
+        return {
+          value: option.id,
+          title: getAttr(option.label, language),
+          label: getAttr(option.label, language),
+        };
+      })
+      .filter(Boolean);
+
+  const getContactSelectValue = () =>
+    (hearing.contact_persons || [])
+      .map((item) => {
+        const option =
+          typeof item === 'object'
+            ? item
+            : contactPersons.find((person) => person.id === item);
+
+        if (!option) {
+          return null;
+        }
+
+        return {
+          value: option.id,
+          label: option.name,
+        };
+      })
+      .filter(Boolean);
+
+  const onLabelsChange = (labels = []) => {
     const newLabels = labelOptions.filter((item) =>
       labels.some((label) => item.id === label.value)
     );
-    setSelectedLabels(newLabels.map(({ id }) => id));
     onHearingChange(
       'labels',
       newLabels.map(({ id }) => id)
     );
   };
 
-  const onContactsChange = (contacts) => {
+  const onContactsChange = (contacts = []) => {
     const newContacts = contactPersons.filter((item) =>
       contacts.some((contact) => item.id === contact.value)
     );
-    setSelectedContacts(newContacts.filter(Boolean).map(({ id }) => id));
     onHearingChange(
       'contact_persons',
       newContacts.map(({ id }) => id)
@@ -72,12 +110,12 @@ const HearingFormStep1 = ({
   };
 
   const onCreateLabel = (label) => {
-    dispatch(addLabel(label, selectedLabels));
+    dispatch(addLabel(label, selectedLabelIds));
   };
 
   const onCreateContact = async (contact) => {
     try {
-      await dispatch(addContact(contact, selectedContacts));
+      await dispatch(addContact(contact, selectedContactIds));
       await dispatch(fetchHearingEditorContactPersons());
       return true;
     } catch (error) {
@@ -150,12 +188,8 @@ const HearingFormStep1 = ({
                   : option.label.toString();
               return label.includes(inputValue.toLowerCase());
             }}
-            value={hearing.labels.map((opt) => ({
-              value: opt.id,
-              title: getAttr(opt.label, language),
-              label: getAttr(opt.label, language),
-            }))}
-            onClose={onLabelsChange}
+            value={getLabelSelectValue()}
+            onChange={onLabelsChange}
             options={labelOptions.map((opt) => ({
               value: opt.id,
               title: getAttr(opt.label, language),
@@ -185,7 +219,7 @@ const HearingFormStep1 = ({
             id='slug'
             name='slug'
             label={<FormattedMessage id='hearingSlug' />}
-            value={hearing.slug}
+            value={hearing.slug || ''}
             placeholder={intl.formatMessage({ id: 'hearingSlugPlaceholder' })}
             onChange={(event) => {
               const { value } = event.target;
@@ -203,7 +237,7 @@ const HearingFormStep1 = ({
           <Select
             multiSelect
             name='contact_persons'
-            onClose={onContactsChange}
+            onChange={onContactsChange}
             filter={(option, inputValue) => {
               const label =
                 typeof option.label === 'string'
@@ -211,12 +245,7 @@ const HearingFormStep1 = ({
                   : option.label.toString();
               return label.includes(inputValue.toLowerCase());
             }}
-            value={hearing.contact_persons.filter(Boolean).map((person) => {
-              return {
-                value: person.id,
-                label: person.name,
-              };
-            })}
+            value={getContactSelectValue()}
             options={contactPersons.map((person) => {
               return { value: person.id, label: person.name };
             })}
@@ -242,8 +271,7 @@ const HearingFormStep1 = ({
       </div>
 
       <ul className='edit-contacts-list hearing-contacts'>
-        {selectedContacts &&
-          selectedContacts.map((item) => {
+        {selectedContactIds.map((item) => {
             const contact = contactPersons.find((option) => option.id === item);
             if (!contact) return null;
             return (

--- a/src/components/admin/HearingFormStep1.jsx
+++ b/src/components/admin/HearingFormStep1.jsx
@@ -45,7 +45,9 @@ const HearingFormStep1 = ({
   const [showLabelModal, setShowLabelModal] = useState(false);
   const [contactInfo, setContactInfo] = useState({});
   const [showContactModal, setShowContactModal] = useState(false);
-  const selectedLabelIds = (hearing?.labels || []).map(getItemId).filter(Boolean);
+  const selectedLabelIds = (hearing?.labels || [])
+    .map(getItemId)
+    .filter(Boolean);
   const selectedContactIds = (hearing?.contact_persons || [])
     .map(getItemId)
     .filter(Boolean);
@@ -272,23 +274,23 @@ const HearingFormStep1 = ({
 
       <ul className='edit-contacts-list hearing-contacts'>
         {selectedContactIds.map((item) => {
-            const contact = contactPersons.find((option) => option.id === item);
-            if (!contact) return null;
-            return (
-              <li key={contact.id} className='hearing-contact'>
-                <ContactCard {...contact} />
-                <Button
-                  className='kerrokantasi-btn'
-                  variant='supplementary'
-                  size='small'
-                  onClick={() => openContactModal(contact)}
-                  aria-label={`Muokkaa yhteyshenkilöä: ${contact.name}`}
-                >
-                  <Icon className='icon' name='edit' />
-                </Button>
-              </li>
-            );
-          })}
+          const contact = contactPersons.find((option) => option.id === item);
+          if (!contact) return null;
+          return (
+            <li key={contact.id} className='hearing-contact'>
+              <ContactCard {...contact} />
+              <Button
+                className='kerrokantasi-btn'
+                variant='supplementary'
+                size='small'
+                onClick={() => openContactModal(contact)}
+                aria-label={`Muokkaa yhteyshenkilöä: ${contact.name}`}
+              >
+                <Icon className='icon' name='edit' />
+              </Button>
+            </li>
+          );
+        })}
       </ul>
       <div className='step-footer'>
         <Button className='kerrokantasi-btn' onClick={onContinue}>

--- a/src/components/admin/__tests__/HearingFormStep1.test.jsx
+++ b/src/components/admin/__tests__/HearingFormStep1.test.jsx
@@ -90,7 +90,9 @@ describe('<HearingFormStep1 />', () => {
     });
 
     await waitFor(() => {
-      expect(onHearingChange).toHaveBeenCalledWith('labels', [labels.data[0].id]);
+      expect(onHearingChange).toHaveBeenCalledWith('labels', [
+        labels.data[0].id,
+      ]);
     });
   });
 

--- a/src/components/admin/__tests__/HearingFormStep1.test.jsx
+++ b/src/components/admin/__tests__/HearingFormStep1.test.jsx
@@ -14,7 +14,7 @@ const renderComponent = (propOverrides) => {
   const { labels, mockHearingWithSections } = mockData;
 
   const props = {
-    hearing: { title: { fi: '' }, labels: [], contact_persons: [] },
+    hearing: { title: { fi: '' }, labels: [], contact_persons: [], slug: '' },
     labels: labels.data,
     contactPersons: mockHearingWithSections.data.contact_persons,
     hearingLanguages: ['fi'],
@@ -89,23 +89,16 @@ describe('<HearingFormStep1 />', () => {
       await user.click(option);
     });
 
-    // Verify that the option was selected by checking the button content
     await waitFor(() => {
-      expect(dropdownButton).toHaveTextContent('Mock Von Label');
+      expect(onHearingChange).toHaveBeenCalledWith('labels', [labels.data[0].id]);
     });
-
-    // Since the HDS Select has a bug in testing environment where onClose doesn't trigger,
-    // let's manually verify the selection was made and skip the onClose test
-    expect(dropdownButton.getAttribute('aria-label')).toContain(
-      '1 valittu vaihtoehto'
-    );
   });
 
-  it('should call onContactsChange when contacts are changed', async () => {
+  it('should call onHearingChange when contacts are changed', async () => {
     const { mockHearingWithSections } = mockData;
-    const onContactsChange = vi.fn();
+    const onHearingChange = vi.fn();
     const user = userEvent.setup();
-    const { container } = renderComponent({ onContactsChange });
+    const { container } = renderComponent({ onHearingChange });
 
     const dropdownButton = container.querySelector(
       '#contact_persons-main-button'
@@ -122,9 +115,56 @@ describe('<HearingFormStep1 />', () => {
     await act(async () => {
       await user.click(option);
     });
-    expect(dropdownButton.getAttribute('aria-label')).toContain(
-      '1 valittu vaihtoehto'
+
+    await waitFor(() => {
+      expect(onHearingChange).toHaveBeenCalledWith('contact_persons', [
+        mockHearingWithSections.data.contact_persons[0].id,
+      ]);
+    });
+  });
+
+  it('should keep keyboard-selected labels visible after moving focus to slug', async () => {
+    const { labels } = mockData;
+    const user = userEvent.setup();
+    const { container, rerender } = renderComponent();
+
+    const dropdownButton = container.querySelector('#labels-main-button');
+    const slugInput = screen.getByRole('textbox', { name: /hearingSlug/i });
+
+    expect(dropdownButton).toBeInTheDocument();
+    expect(slugInput).toBeInTheDocument();
+
+    await act(async () => {
+      dropdownButton.focus();
+      await user.keyboard('[Enter]');
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[Enter]');
+      await user.keyboard('[Tab]');
+      await user.type(slugInput, 'slug-value');
+    });
+
+    rerender(
+      <HearingFormStep1
+        hearing={{
+          title: { fi: '' },
+          labels: [labels.data[0]],
+          contact_persons: [],
+          slug: 'slug-value',
+        }}
+        labels={labels.data}
+        contactPersons={mockData.mockHearingWithSections.data.contact_persons}
+        hearingLanguages={['fi']}
+        onLanguagesChange={vi.fn()}
+        onHearingChange={vi.fn()}
+        onContinue={vi.fn()}
+        errors={{}}
+        organizations={[]}
+      />
     );
+
+    await waitFor(() => {
+      expect(dropdownButton).toHaveTextContent(labels.data[0].label.fi);
+    });
   });
 
   it('should call onContinue when continue button is clicked', () => {
@@ -135,5 +175,19 @@ describe('<HearingFormStep1 />', () => {
     fireEvent.click(screen.getByText(/hearingFormNext/i));
 
     expect(onContinue).toHaveBeenCalled();
+  });
+
+  it('should call onContinue when continue button is activated with keyboard', async () => {
+    const onContinue = vi.fn();
+    const user = userEvent.setup();
+
+    renderComponent({ onContinue });
+
+    const button = screen.getByRole('button', { name: /hearingFormNext/i });
+    button.focus();
+
+    await user.keyboard('[Enter]');
+
+    expect(onContinue).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -148,6 +148,7 @@
   "hearingContacts": "Contacts",
   "hearingContactsPlaceholder": "Select Hearing Contacts",
   "hearingFormHeaderContainsErrors": " - contains errors",
+  "hearingFormHeaderStep0": "Errors",
   "hearingFormHeaderStep1": "1. Basic information of the hearing",
   "hearingFormHeaderStep2": "2. Content",
   "hearingFormHeaderStep3": "3. Map",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -148,6 +148,7 @@
   "hearingContacts": "Yhteyshenkilöt",
   "hearingContactsPlaceholder": "Valitse kuulemisen yhteyshenkilöt",
   "hearingFormHeaderContainsErrors": " - sisältää virheitä",
+  "hearingFormHeaderStep0": "Virheet",
   "hearingFormHeaderStep1": "1. Kuulemisen perustiedot",
   "hearingFormHeaderStep2": "2. Sisältö",
   "hearingFormHeaderStep3": "3. Kartta",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -148,6 +148,7 @@
   "hearingContacts": "Kontakter",
   "hearingContactsPlaceholder": "Välj hörselkontakter",
   "hearingFormHeaderContainsErrors": " - innehåller fel",
+  "hearingFormHeaderStep0": "Fel",
   "hearingFormHeaderStep1": "1. Hörandets grundläggande information",
   "hearingFormHeaderStep2": "2. Innehåll",
   "hearingFormHeaderStep3": "3. Karta",

--- a/src/reducers/hearingEditor/__tests__/sections.test.js
+++ b/src/reducers/hearingEditor/__tests__/sections.test.js
@@ -1,0 +1,56 @@
+import reducer from '../sections';
+import { EditorActions } from '../../../actions/hearingEditor';
+
+describe('sections reducer', () => {
+  it('should ignore image caption changes when the section has no images', () => {
+    const state = {
+      byId: {
+        'section-1': {
+          frontId: 'section-1',
+          images: [],
+        },
+      },
+      all: ['section-1'],
+      isFetching: false,
+    };
+
+    const action = {
+      type: EditorActions.CHANGE_SECTION_MAIN_IMAGE_CAPTION,
+      payload: {
+        sectionID: 'section-1',
+        value: { fi: '' },
+      },
+    };
+
+    const nextState = reducer(state, action);
+
+    expect(nextState).toEqual(state);
+  });
+
+  it('should update the caption for an existing section image', () => {
+    const state = {
+      byId: {
+        'section-1': {
+          frontId: 'section-1',
+          images: [{ id: 'img-1', caption: { fi: 'old' }, url: '/test.jpg' }],
+        },
+      },
+      all: ['section-1'],
+      isFetching: false,
+    };
+
+    const action = {
+      type: EditorActions.CHANGE_SECTION_MAIN_IMAGE_CAPTION,
+      payload: {
+        sectionID: 'section-1',
+        value: { fi: 'new' },
+      },
+    };
+
+    const nextState = reducer(state, action);
+
+    expect(nextState.byId['section-1'].images).toEqual([
+      { id: 'img-1', caption: { fi: 'new' }, url: '/test.jpg' },
+    ]);
+  });
+});

--- a/src/reducers/hearingEditor/sections.js
+++ b/src/reducers/hearingEditor/sections.js
@@ -265,6 +265,10 @@ const byId = handleActions(
       state,
       { payload: { sectionID, value } }
     ) => {
+      if (!state[sectionID].images.length) {
+        return state;
+      }
+
       const setSection = {
         ...state[sectionID],
         images: [{ ...state[sectionID].images[0], caption: value }],


### PR DESCRIPTION

## Improve keyboard navigation when entering new hearing


- Selects were using double state which caused results being different with mouse & keyboard
- Continue button moved focus to the step that was open and most further away. Changed it so that the button moves always to the next step.
- If user "touched" image fields for example with keyboard focus the app sent empty image array to backend and it caused an error. Fixed it so that image data is only sent if there actually is an image. 
- Richtext editor caught Tab keys. So user could not move focus out of the rich text editor with keyboard. Now it's possible.
- Fixed a memory leak with accordion click listeners
- Added missing localisation text: Virheet / Errors / Fel



https://helsinkisolutionoffice.atlassian.net/browse/KER-597

Refs: KER-597

